### PR TITLE
Add directed-graph visualization for payoff matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,21 @@ wheels/
 .vscode/
 
 .pytest_cache/
+
+# Binary artifacts
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.bmp
+*.webp
+*.pdf
+*.zip
+*.tar
+*.gz
+*.7z
+*.exe
+*.dll
+*.so
+*.dylib
+*.bin

--- a/src/monocycle_nash/visualization/__init__.py
+++ b/src/monocycle_nash/visualization/__init__.py
@@ -1,0 +1,5 @@
+"""可視化機能。"""
+
+from .payoff_graph import PayoffDirectedGraphPlotter
+
+__all__ = ["PayoffDirectedGraphPlotter"]

--- a/src/monocycle_nash/visualization/payoff_graph.py
+++ b/src/monocycle_nash/visualization/payoff_graph.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import math
+import numpy as np
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    """有向グラフの辺情報。"""
+
+    source: int
+    target: int
+    value: float
+
+
+class PayoffDirectedGraphPlotter:
+    """利得行列から純粋戦略間の有向グラフ画像(SVG)を生成する。"""
+
+    def __init__(self, payoff_matrix: np.ndarray, labels: list[str], threshold: float = 0.0):
+        matrix = np.asarray(payoff_matrix, dtype=float)
+        if matrix.ndim != 2:
+            raise ValueError("payoff_matrix は2次元配列である必要があります")
+        if matrix.shape[0] != matrix.shape[1]:
+            raise ValueError("交代行列を想定するため、正方行列が必要です")
+        if len(labels) != matrix.shape[0]:
+            raise ValueError("labels の数は行列サイズと一致する必要があります")
+
+        self._matrix = matrix
+        self._labels = labels
+        self._threshold = float(threshold)
+
+    def extract_edges(self) -> list[GraphEdge]:
+        edges: list[GraphEdge] = []
+        size = self._matrix.shape[0]
+        for i in range(size):
+            for j in range(size):
+                if i == j:
+                    continue
+                value = float(self._matrix[i, j])
+                if value > self._threshold:
+                    edges.append(GraphEdge(i, j, value))
+        return edges
+
+    def draw(self, output_path: str | Path, canvas_size: int = 840) -> Path:
+        """有向グラフをSVG画像として保存。"""
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        center = canvas_size / 2
+        radius = canvas_size * 0.34
+        node_r = 42
+        positions = self._circle_layout(self._matrix.shape[0], center, radius)
+        edges = self.extract_edges()
+
+        max_value = max((edge.value for edge in edges), default=1.0)
+
+        svg_parts: list[str] = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{canvas_size}" height="{canvas_size}">',
+            '<defs><marker id="arrow" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">'
+            '<polygon points="0 0, 10 3.5, 0 7" fill="#1d4ed8" /></marker></defs>',
+            '<rect width="100%" height="100%" fill="white" />',
+        ]
+
+        for edge in edges:
+            start = positions[edge.source]
+            end = positions[edge.target]
+            dx = end[0] - start[0]
+            dy = end[1] - start[1]
+            dist = math.hypot(dx, dy)
+            ux, uy = dx / dist, dy / dist
+            sx, sy = start[0] + ux * node_r, start[1] + uy * node_r
+            tx, ty = end[0] - ux * node_r, end[1] - uy * node_r
+
+            norm = edge.value / max_value if max_value > 0 else 0.0
+            stroke_width = 1.5 + 5.0 * norm
+            opacity = 0.4 + 0.6 * norm
+
+            svg_parts.append(
+                f'<line x1="{sx:.2f}" y1="{sy:.2f}" x2="{tx:.2f}" y2="{ty:.2f}" '
+                f'stroke="#1d4ed8" stroke-width="{stroke_width:.2f}" opacity="{opacity:.3f}" marker-end="url(#arrow)" />'
+            )
+
+            mx, my = (sx + tx) / 2, (sy + ty) / 2
+            svg_parts.append(
+                f'<text x="{mx:.2f}" y="{my:.2f}" text-anchor="middle" dominant-baseline="middle" '
+                f'font-size="14" fill="#1e40af">{edge.value:.2f}</text>'
+            )
+
+        for i, (x, y) in enumerate(positions):
+            label = self._escape(self._labels[i])
+            svg_parts.append(f'<circle cx="{x:.2f}" cy="{y:.2f}" r="{node_r}" fill="#e5e7eb" stroke="#111827" stroke-width="2" />')
+            svg_parts.append(
+                f'<text x="{x:.2f}" y="{y:.2f}" text-anchor="middle" dominant-baseline="middle" '
+                f'font-size="15" fill="#111827">{label}</text>'
+            )
+
+        svg_parts.append('</svg>')
+        output.write_text("\n".join(svg_parts), encoding="utf-8")
+        return output
+
+    @staticmethod
+    def _circle_layout(size: int, center: float, radius: float) -> list[tuple[float, float]]:
+        angles = np.linspace(0, 2 * np.pi, size, endpoint=False)
+        return [
+            (float(center + radius * np.cos(theta)), float(center + radius * np.sin(theta)))
+            for theta in angles
+        ]
+
+    @staticmethod
+    def _escape(text: str) -> str:
+        return (
+            text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#39;")
+        )

--- a/tests/visualization/test_payoff_graph.py
+++ b/tests/visualization/test_payoff_graph.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from monocycle_nash.visualization import PayoffDirectedGraphPlotter
+
+
+def test_extract_edges_respects_positive_and_threshold() -> None:
+    matrix = np.array(
+        [
+            [0.0, 0.4, -0.2],
+            [-0.4, 0.0, 0.9],
+            [0.2, -0.9, 0.0],
+        ]
+    )
+    labels = ["A", "B", "C"]
+    plotter = PayoffDirectedGraphPlotter(matrix, labels, threshold=0.3)
+
+    edges = plotter.extract_edges()
+
+    assert [(e.source, e.target, e.value) for e in edges] == [
+        (0, 1, 0.4),
+        (1, 2, 0.9),
+    ]
+
+
+def test_draw_creates_svg_file(tmp_path) -> None:
+    matrix = np.array(
+        [
+            [0.0, 0.8, 0.0],
+            [0.0, 0.0, 0.5],
+            [0.3, 0.0, 0.0],
+        ]
+    )
+    labels = ["キャラA", "キャラB", "キャラC"]
+    plotter = PayoffDirectedGraphPlotter(matrix, labels, threshold=0.2)
+
+    output = tmp_path / "payoff_graph.svg"
+    saved_path = plotter.draw(output)
+
+    assert saved_path.exists()
+    assert saved_path.suffix == ".svg"
+    content = saved_path.read_text(encoding="utf-8")
+    assert "キャラA" in content
+    assert "0.80" in content


### PR DESCRIPTION
### Motivation
- Provide a visual representation of pairwise payoffs for symmetric (square) payoff matrices to make strategy relationships easier to inspect.
- Allow filtering of insignificant edges by a threshold so only meaningful directed wins are shown.
- Put node labels and numeric payoff annotations on edges so strategies and payoff magnitudes are readable.
- Ensure generated images are not checked into git by ignoring common binary/image extensions.

### Description
- Added `PayoffDirectedGraphPlotter` (`src/monocycle_nash/visualization/payoff_graph.py`) which extracts directed edges where `A[i, j] > threshold` and renders an SVG diagram with nodes, arrows and payoff labels.
- Edge styling (stroke width and opacity) is scaled by payoff magnitude, and node labels are escaped and placed on circular layout positions; `draw()` writes the SVG to the specified path.
- Exported the plotter via `src/monocycle_nash/visualization/__init__.py` so it can be imported as `from monocycle_nash.visualization import PayoffDirectedGraphPlotter`.
- Added tests `tests/visualization/test_payoff_graph.py` covering `extract_edges()` behavior and SVG output content, and updated `.gitignore` to exclude common binary/image extensions (e.g. `*.png`, `*.jpg`, `*.svg`-adjacent entries).

### Testing
- Ran the new visualization tests with `PYTHONPATH=src .venv/bin/python -m pytest tests/visualization/test_payoff_graph.py` and they passed (2 tests). 
- Ran existing matrix tests with `PYTHONPATH=src .venv/bin/python -m pytest tests/matrix/test_general.py` and they passed (14 tests). 
- An initial `uv run pytest` attempt failed due to external network/PyPI fetch errors unrelated to the new code (failed to fetch `https://pypi.org/simple/nashpy/`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f2e1b0c2c8330b9cc906a10ab6715)