### PR TITLE
Add CharacterVectorGraphPlotter: SVG scatter plot of character vectors with power-scaled circles

### DIFF
--- a/src/monocycle_nash/visualization/__init__.py
+++ b/src/monocycle_nash/visualization/__init__.py
@@ -1,5 +1,6 @@
 """可視化機能。"""
 
 from .payoff_graph import PayoffDirectedGraphPlotter
+from .character_vector_graph import CharacterVectorGraphPlotter
 
-__all__ = ["PayoffDirectedGraphPlotter"]
+__all__ = ["PayoffDirectedGraphPlotter", "CharacterVectorGraphPlotter"]

--- a/src/monocycle_nash/visualization/character_vector_graph.py
+++ b/src/monocycle_nash/visualization/character_vector_graph.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from monocycle_nash.character import Character
+
+
+class CharacterVectorGraphPlotter:
+    """単相性モデルのキャラクター配列から相性ベクトル散布図(SVG)を生成する。"""
+
+    def __init__(self, characters: list[Character]):
+        if not characters:
+            raise ValueError("characters は1件以上必要です")
+        self._characters = characters
+
+    def draw(self, output_path: str | Path, canvas_size: int = 840, margin: int = 90) -> Path:
+        output = Path(output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+
+        xs = [float(c.v.x) for c in self._characters]
+        ys = [float(c.v.y) for c in self._characters]
+        min_x, max_x = min(xs), max(xs)
+        min_y, max_y = min(ys), max(ys)
+
+        # 表示領域が狭い場合にも一定の余白を確保する
+        span_x = max(max_x - min_x, 1e-6)
+        span_y = max(max_y - min_y, 1e-6)
+        pad_x = span_x * 0.2
+        pad_y = span_y * 0.2
+        world_min_x, world_max_x = min_x - pad_x, max_x + pad_x
+        world_min_y, world_max_y = min_y - pad_y, max_y + pad_y
+
+        width = canvas_size
+        height = canvas_size
+        inner_w = width - margin * 2
+        inner_h = height - margin * 2
+
+        def sx(x: float) -> float:
+            return margin + (x - world_min_x) / (world_max_x - world_min_x) * inner_w
+
+        def sy(y: float) -> float:
+            # SVGはy軸が下向きのため反転
+            return height - margin - (y - world_min_y) / (world_max_y - world_min_y) * inner_h
+
+        powers = [float(c.p) for c in self._characters]
+        min_p, max_p = min(powers), max(powers)
+
+        def radius(p: float) -> float:
+            if max_p == min_p:
+                return 28.0
+            norm = (p - min_p) / (max_p - min_p)
+            return 18.0 + norm * 28.0
+
+        axis_x0 = sx(world_min_x)
+        axis_x1 = sx(world_max_x)
+        axis_y0 = sy(world_min_y)
+        axis_y1 = sy(world_max_y)
+        zero_x = sx(0.0) if world_min_x <= 0.0 <= world_max_x else None
+        zero_y = sy(0.0) if world_min_y <= 0.0 <= world_max_y else None
+
+        svg_parts: list[str] = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">',
+            '<rect width="100%" height="100%" fill="white" />',
+            f'<line x1="{axis_x0:.2f}" y1="{axis_y0:.2f}" x2="{axis_x1:.2f}" y2="{axis_y0:.2f}" stroke="#d1d5db" stroke-width="1" />',
+            f'<line x1="{axis_x0:.2f}" y1="{axis_y1:.2f}" x2="{axis_x0:.2f}" y2="{axis_y0:.2f}" stroke="#d1d5db" stroke-width="1" />',
+        ]
+
+        if zero_y is not None:
+            svg_parts.append(
+                f'<line x1="{axis_x0:.2f}" y1="{zero_y:.2f}" x2="{axis_x1:.2f}" y2="{zero_y:.2f}" stroke="#6b7280" stroke-width="1.5" />'
+            )
+        if zero_x is not None:
+            svg_parts.append(
+                f'<line x1="{zero_x:.2f}" y1="{axis_y1:.2f}" x2="{zero_x:.2f}" y2="{axis_y0:.2f}" stroke="#6b7280" stroke-width="1.5" />'
+            )
+
+        for c in self._characters:
+            x = sx(float(c.v.x))
+            y = sy(float(c.v.y))
+            r = radius(float(c.p))
+            label = self._escape(c.label)
+
+            svg_parts.append(
+                f'<circle cx="{x:.2f}" cy="{y:.2f}" r="{r:.2f}" fill="#dbeafe" stroke="#2563eb" stroke-width="2" opacity="0.88" />'
+            )
+            svg_parts.append(
+                f'<text x="{x:.2f}" y="{y:.2f}" text-anchor="middle" dominant-baseline="middle" '
+                f'font-size="14" fill="#1e3a8a">{label}</text>'
+            )
+
+        svg_parts.append('</svg>')
+        output.write_text("\n".join(svg_parts), encoding="utf-8")
+        return output
+
+    @staticmethod
+    def _escape(text: str) -> str:
+        return (
+            text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#39;")
+        )

--- a/tests/visualization/test_character_vector_graph.py
+++ b/tests/visualization/test_character_vector_graph.py
@@ -1,0 +1,32 @@
+from monocycle_nash.character import Character, MatchupVector
+from monocycle_nash.visualization import CharacterVectorGraphPlotter
+
+
+def test_draw_creates_svg_with_labels_and_power_scaled_circles(tmp_path) -> None:
+    characters = [
+        Character(1.0, MatchupVector(-1.0, 0.5), "キャラA"),
+        Character(3.0, MatchupVector(0.5, -0.2), "キャラB"),
+        Character(9.0, MatchupVector(1.2, 0.8), "キャラC"),
+    ]
+    plotter = CharacterVectorGraphPlotter(characters)
+
+    output = tmp_path / "character_vectors.svg"
+    saved = plotter.draw(output)
+
+    assert saved.exists()
+    content = saved.read_text(encoding="utf-8")
+    assert "キャラA" in content
+    assert "キャラB" in content
+    assert "キャラC" in content
+
+    # powerの大小に応じて半径が増えることを確認
+    assert 'r="18.00"' in content
+    assert 'r="46.00"' in content
+
+
+def test_plotter_requires_non_empty_characters() -> None:
+    try:
+        CharacterVectorGraphPlotter([])
+        assert False, "ValueError が発生するべき"
+    except ValueError as exc:
+        assert "1件以上" in str(exc)


### PR DESCRIPTION
### Motivation

- 単相性モデルのキャラクター配列を受け取り、各キャラクターの相性ベクトル `(x, y)` を2次元平面にプロットして可視化する機能が必要だったため。 
- キャラクターの `power` に応じてラベルを囲む円の大きさを変えることで影響力の差を直感的に示す必要があった。
- 可視化APIを `monocycle_nash.visualization` から利用可能にして他モジュールから呼び出しやすくするため。 

### Description

- 新規に `CharacterVectorGraphPlotter` を `src/monocycle_nash/visualization/character_vector_graph.py` に追加し、`draw()` で座標変換・軸描画・ラベル描画と `power` による円サイズスケーリングを行う実装を追加しました。 
- SVG出力で安全に表示するためにラベルのエスケープ処理を実装しています（`_escape` メソッド）。
- `src/monocycle_nash/visualization/__init__.py` を更新して `CharacterVectorGraphPlotter` を公開APIに追加しました。 
- 新規テスト `tests/visualization/test_character_vector_graph.py` を追加し、SVG生成・ラベル出力・パワーに基づく半径スケーリングおよび空配列入力時の例外を検証するケースを実装しました。 

### Testing

- 実行したコマンド: `pytest -q tests/visualization/test_character_vector_graph.py tests/visualization/test_payoff_graph.py`, 収集段階で `ModuleNotFoundError: No module named 'monocycle_nash'` と `ModuleNotFoundError: No module named 'numpy'` により失敗しました。 
- 依存解決を試したコマンド: `uv run pytest -q tests/visualization/test_character_vector_graph.py tests/visualization/test_payoff_graph.py`, ビルドフェーズで `numpy==2.4.2` のダウンロードに失敗しパッケージ解決ができず失敗しました。 
- 以上の結果により追加したテストは現環境では実行できておらず、自動テストは全て失敗しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fbc5f00a08330a5013da730b80b6b)