### PR TITLE
Define strategy metadata contract on PayoffMatrix

### DIFF
--- a/src/monocycle_nash/matrix/base.py
+++ b/src/monocycle_nash/matrix/base.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..equilibrium.domain import MixedStrategy
+    from ..strategy.domain import PureStrategySet
 
 
 class PayoffMatrix(ABC):
@@ -20,6 +21,23 @@ class PayoffMatrix(ABC):
     def size(self) -> int:
         """行列のサイズ"""
         pass
+
+    @property
+    @abstractmethod
+    def row_strategies(self) -> "PureStrategySet":
+        """行プレイヤー側の純粋戦略集合"""
+        pass
+
+    @property
+    @abstractmethod
+    def col_strategies(self) -> "PureStrategySet":
+        """列プレイヤー側の純粋戦略集合"""
+        pass
+
+    @property
+    def labels(self) -> list[str]:
+        """後方互換: 行プレイヤー側ラベル。"""
+        return self.row_strategies.labels
     
     @abstractmethod
     def solve_equilibrium(self) -> "MixedStrategy":


### PR DESCRIPTION
### Motivation

- Consumers treat objects typed as `PayoffMatrix` as exposing strategy-set metadata (e.g. `row_strategies`), so the abstract interface must declare those properties to match subclass behaviour. 
- Providing a default `labels` getter in the base class centralizes backward-compatible label access and avoids duplication across subclasses.

### Description

- Added abstract properties `row_strategies` and `col_strategies` to `PayoffMatrix` so subclasses must expose the associated `PureStrategySet` interfaces. 
- Added a default `labels` property on the base class that returns `self.row_strategies.labels` for backward compatibility. 
- Added a `TYPE_CHECKING` import for `PureStrategySet` to keep type hints correct without runtime imports.

### Testing

- Ran `python -m compileall src/monocycle_nash/matrix/base.py`, which succeeded. 
- Attempted `pytest -q tests/matrix/test_general.py tests/matrix/test_monocycle.py tests/solver/test_nashpy_solver.py tests/solver/test_isopower_solver.py`, but collection failed due to missing dependency `numpy` (error: `ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69901e5490c88330b6bffdb9442f5a5d)