### PR TITLE
相性ベクトル散布図で原点(0,0)を常時明示

### DIFF
--- a/src/monocycle_nash/visualization/character_vector_graph.py
+++ b/src/monocycle_nash/visualization/character_vector_graph.py
@@ -80,8 +80,16 @@ class CharacterVectorGraphPlotter:
         svg_parts.append(
             f'<circle cx="{zero_x:.2f}" cy="{zero_y:.2f}" r="5.50" fill="#ef4444" stroke="white" stroke-width="1.5" />'
         )
+        label_offset = 10.0
+        if zero_x > width - margin - 80.0:
+            label_x = zero_x - label_offset
+            label_anchor = "end"
+        else:
+            label_x = zero_x + label_offset
+            label_anchor = "start"
+
         svg_parts.append(
-            f'<text x="{zero_x + 10:.2f}" y="{zero_y - 10:.2f}" text-anchor="start" dominant-baseline="baseline" '
+            f'<text x="{label_x:.2f}" y="{zero_y - 10:.2f}" text-anchor="{label_anchor}" dominant-baseline="baseline" '
             f'font-size="14" fill="#991b1b">原点 (0, 0)</text>'
         )
 

--- a/tests/visualization/test_character_vector_graph.py
+++ b/tests/visualization/test_character_vector_graph.py
@@ -45,3 +45,18 @@ def test_draw_always_marks_origin(tmp_path) -> None:
     content = saved.read_text(encoding="utf-8")
     assert "原点 (0, 0)" in content
     assert 'fill="#ef4444"' in content
+
+
+def test_draw_origin_label_keeps_readable_position_when_zero_is_right_edge(tmp_path) -> None:
+    characters = [
+        Character(1.0, MatchupVector(-4.0, -1.0), "キャラF"),
+        Character(2.0, MatchupVector(-1.5, 2.0), "キャラG"),
+    ]
+    plotter = CharacterVectorGraphPlotter(characters)
+
+    output = tmp_path / "character_vectors_origin_negative_x.svg"
+    saved = plotter.draw(output)
+
+    content = saved.read_text(encoding="utf-8")
+    assert "原点 (0, 0)" in content
+    assert 'text-anchor="end"' in content


### PR DESCRIPTION
### Motivation
- 相性ベクトルの可視化では原点の位置が解釈上重要なため、プロットでどこが原点か常に明示する必要がある。 

### Description
- `CharacterVectorGraphPlotter.draw()`で表示範囲 (`world_min_x/world_max_x/world_min_y/world_max_y`) に必ず原点 `(0, 0)` を含めるように変更した。 (`src/monocycle_nash/visualization/character_vector_graph.py`) 
- 原点のX/Y軸を常時描画するようにし、原点位置に赤いマーカー（`<circle ... fill="#ef4444" />`）とラベル `原点 (0, 0)` を追加した。 (`src/monocycle_nash/visualization/character_vector_graph.py`) 
- 可視化が全データ点と同じ象限に偏るケースでも原点が表示されることを検証するテスト `test_draw_always_marks_origin` を追加した。 (`tests/visualization/test_character_vector_graph.py`) 

### Testing
- 自動テストを `uv run pytest` で実行し、全テストが成功して `190 passed, 3 warnings` となった。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699027d8a8988330b05cf7655b6ff243)