### PR TITLE
Resolve run_config refs and load matrix/graph/setting via data loaders

### DIFF
--- a/tests/entrypoints/test_common.py
+++ b/tests/entrypoints/test_common.py
@@ -69,3 +69,42 @@ def test_build_matrix_from_characters_rejects_duplicate_labels() -> None:
                 ]
             }
         )
+
+
+def test_load_inputs_requires_graph_when_entrypoint_needs_it(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "run_config" / "baseline" / "rps3_solve.toml",
+        '''
+        matrix = "rps3"
+        setting = "local"
+        ''',
+    )
+    _write(
+        tmp_path / "data" / "matrix" / "rps3" / "data.toml",
+        '''
+        matrix = [[0, 1, -1], [-1, 0, 1], [1, -1, 0]]
+        ''',
+    )
+    _write(
+        tmp_path / "data" / "setting" / "local.toml",
+        '''
+        [output]
+        base_dir = "result"
+        ''',
+    )
+
+    with pytest.raises(ValueError, match="run_config.graph"):
+        load_inputs("baseline/rps3_solve", tmp_path / "data", require_graph=True)
+
+
+def test_load_inputs_rejects_empty_run_config_reference(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "data" / "run_config" / "baseline" / "invalid.toml",
+        '''
+        matrix = ""
+        setting = "local"
+        ''',
+    )
+
+    with pytest.raises(ValueError, match="空でない文字列"):
+        load_inputs("baseline/invalid", tmp_path / "data", require_graph=False)


### PR DESCRIPTION
### Motivation
- Align entrypoint input loading with the documented `data/<class>/<id>/data.toml` flow by resolving `run_config` references before loading the actual `matrix` / `graph` / `setting` data. 
- Centralize and validate `run_config` keys (`matrix`, `graph`, `setting`) to provide clearer errors for empty or missing references and to support entrypoints that optionally require a graph.

### Description
- Added `_resolve_run_config_refs`, `_require_run_config_str`, and `_optional_run_config_str` helpers and a small `_RunConfigRefs` holder class to validate and extract `run_config` references. 
- Changed `load_inputs` to call the resolver first and then load inputs using `ExperimentDataLoader.load("matrix", ...)`, `ExperimentDataLoader.load("graph", ...)` (when present), and `SettingDataLoader.load(...)` to follow the documented directory conventions. 
- Replaced ad-hoc `cfg` key checks with the new validators that enforce non-empty string types and `require_graph` behavior. 
- Added tests to `tests/entrypoints/test_common.py` to cover the case where `graph` is required and the case where a `run_config` reference is an empty string.

### Testing
- Ran `uv run pytest tests/entrypoints/test_common.py -q` and the targeted tests passed (`5 passed`).
- Ran the full suite with `uv run pytest -q` and all tests passed (`204 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699159617fd883308475626cda0acc2b)