### PR TITLE
Ensure run directory exists under configured output base in entrypoint flow

### DIFF
--- a/src/monocycle_nash/entrypoints/common.py
+++ b/src/monocycle_nash/entrypoints/common.py
@@ -229,6 +229,9 @@ def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessi
         projects.add(project_id=project_id, project_path=project_path or "", created_at=now_jst_iso())
 
     ctx = service.start(command=command, project_id=project_id)
+    # エントリーポイント実装の責務として、
+    # output.base_dir/<run_id>/ の実行ディレクトリを明示的に確保する。
+    service.artifact_store.create_run_dir(ctx.run_id)
     return service, ctx, conn
 
 


### PR DESCRIPTION
### Motivation

- The entrypoint flow must guarantee the physical `output.base_dir/<run_id>/` layout is present for downstream code that writes `input/`, `output/`, and `logs/` files.

### Description

- Call `service.artifact_store.create_run_dir(ctx.run_id)` after `service.start(...)` in `prepare_run_session` to explicitly ensure `output.base_dir/<run_id>/` is created.
- Add `test_prepare_run_session_creates_output_base_dir_run_folder` in `tests/entrypoints/test_common.py` which verifies that `prepare_run_session` creates the run folder and the `input/`, `output/`, and `logs/` subdirectories when a custom `setting.output.base_dir` is supplied.

### Testing

- Ran `uv run pytest tests/entrypoints/test_common.py -q` and the new entrypoint tests passed (`9 passed`).
- Ran the full suite with `uv run pytest -q` and all tests passed (`208 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915d9ced788330ae45e4a6a51e8870)