### PR TITLE
Add Windows junction fallback and directory-to-directory analysis project references

### DIFF
--- a/src/monocycle_nash/entrypoints/common.py
+++ b/src/monocycle_nash/entrypoints/common.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import sqlite3
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -224,15 +227,96 @@ def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessi
     service = RunSessionService(runs_repository=runs, artifact_store=RunArtifactStore(output_root))
 
     project_id = project.get("project_id") if isinstance(project.get("project_id"), str) and project.get("project_id") else None
-    project_path = project.get("project_path") if isinstance(project.get("project_path"), str) else None
-    if project_id and projects.find(project_id) is None:
-        projects.add(project_id=project_id, project_path=project_path or "", created_at=now_jst_iso())
+    project_path = project.get("project_path") if isinstance(project.get("project_path"), str) and project.get("project_path") else None
+    effective_project_path = _ensure_project_linkage(projects, project_id=project_id, project_path=project_path)
 
     ctx = service.start(command=command, project_id=project_id)
     # エントリーポイント実装の責務として、
     # output.base_dir/<run_id>/ の実行ディレクトリを明示的に確保する。
-    service.artifact_store.create_run_dir(ctx.run_id)
+    result_dir = service.artifact_store.create_run_dir(ctx.run_id)
+    _create_analysis_project_reference(run_id=ctx.run_id, result_dir=result_dir, project_path=effective_project_path)
     return service, ctx, conn
+
+
+def _ensure_project_linkage(
+    projects: ProjectsRepository,
+    *,
+    project_id: str | None,
+    project_path: str | None,
+) -> str | None:
+    if project_id is None:
+        return None
+
+    project_row = projects.find(project_id)
+    if project_row is None:
+        stored_path = project_path or ""
+        projects.add(project_id=project_id, project_path=stored_path, created_at=now_jst_iso())
+        return stored_path
+
+    if project_path is not None and project_path != project_row.project_path:
+        projects.update(project_id, project_path=project_path)
+        return project_path
+
+    return project_row.project_path
+
+
+def _create_analysis_project_reference(*, run_id: int, result_dir: Path, project_path: str | None) -> None:
+    if not project_path:
+        return
+
+    refs_dir = Path(project_path) / "experiment_refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    ref_dir = refs_dir / str(run_id)
+    _remove_existing_reference(ref_dir)
+
+    target_dir = result_dir.resolve()
+    try:
+        ref_dir.symlink_to(target_dir, target_is_directory=True)
+        _remove_existing_reference(refs_dir / f"{run_id}.txt")
+        return
+    except OSError:
+        pass
+
+    if _try_create_windows_junction(link_dir=ref_dir, target_dir=target_dir):
+        _remove_existing_reference(refs_dir / f"{run_id}.txt")
+        return
+
+    (refs_dir / f"{run_id}.txt").write_text(
+        "\n".join(
+            [
+                f"result_path={target_dir}",
+                f"created_at={now_jst_iso()}",
+                "status=running",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _remove_existing_reference(path: Path) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return
+    shutil.rmtree(path)
+
+
+def _try_create_windows_junction(*, link_dir: Path, target_dir: Path) -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link_dir), str(target_dir)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, OSError):
+        return False
 
 
 def write_input_snapshots(

--- a/src/monocycle_nash/runmeta/models.py
+++ b/src/monocycle_nash/runmeta/models.py
@@ -27,6 +27,7 @@ class RunRecord:
     git_commit: str | None
     note: str
     project_id: str | None
+    project_path: str | None
     updated_at: str
 
 

--- a/src/monocycle_nash/runmeta/service.py
+++ b/src/monocycle_nash/runmeta/service.py
@@ -98,5 +98,6 @@ class RunSessionService:
             "git_commit": record.git_commit,
             "note": record.note,
             "project_id": record.project_id,
+            "project_path": record.project_path,
             "updated_at": record.updated_at,
         }


### PR DESCRIPTION
### Motivation

- Ensure `analysis_project` references are robust by always creating directory-to-directory links from `experiment_refs/<run_id>` to the run result directory so file-vs-directory ambiguity does not break link creation. 
- Provide a Windows-friendly fallback when creating symlinks fails by attempting a junction (`mklink /J`) before falling back to a `.txt` pointer. 
- Cleanly handle replacing existing references whether they are symlinks, files, or directories.

### Description

- Unified project linkage handling by introducing `_ensure_project_linkage` and using it in `prepare_run_session` to determine and persist the effective `project_path`. (file: `src/monocycle_nash/entrypoints/common.py`) 
- Reworked analysis project reference creation into `_create_analysis_project_reference` which now creates a directory entry `experiment_refs/<run_id>` that points at the resolved result directory, and falls back to writing a `<run_id>.txt` only if both symlink and junction creation fail. (file: `src/monocycle_nash/entrypoints/common.py`) 
- Added `_remove_existing_reference` to safely remove existing symlink/file/directory references before creating a new one. (file: `src/monocycle_nash/entrypoints/common.py`) 
- Added `_try_create_windows_junction` that attempts to create a Windows junction using `cmd /c mklink /J` when `os.name == "nt"`. (file: `src/monocycle_nash/entrypoints/common.py`) 
- Extended run metadata to include `project_path` through the stack: added `project_path` to `RunRecord`, modified repository queries to `LEFT JOIN projects` and select `project_path`, and included `project_path` in the service meta payload. (files: `src/monocycle_nash/runmeta/models.py`, `src/monocycle_nash/runmeta/repositories.py`, `src/monocycle_nash/runmeta/service.py`) 
- Added tests covering: normal linkage creation, updating existing project path, and the fallback path where both symlink and junction creation fail (forcing `.txt` creation). (file: `tests/entrypoints/test_common.py`)

### Testing

- Ran the full test suite with `uv run pytest`, which collected 213 tests and reported `213 passed, 3 warnings`.
- Added and executed targeted tests in `tests/entrypoints/test_common.py` that verify the experiments reference behavior and the `.txt` fallback, and these tests passed as part of the full run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991674268ec8330852483af66b587b3)