### PR TITLE
Improve directed payoff graph readability and edge value encoding

### DIFF
--- a/tests/visualization/test_payoff_graph.py
+++ b/tests/visualization/test_payoff_graph.py
@@ -41,3 +41,6 @@ def test_draw_creates_svg_file(tmp_path) -> None:
     content = saved_path.read_text(encoding="utf-8")
     assert "キャラA" in content
     assert "0.80" in content
+    assert "<rect" in content
+    assert "arrow-0" in content
+    assert "#dc2626" in content


### PR DESCRIPTION
### Motivation

- Edge value labels in the generated SVG overlapped arrows and background, making numbers hard to read, so a label background is needed for clarity.
- Arrow color was previously fixed and only width/opacity indicated magnitude, so adding color encoding improves perceptual distinction of payoff strength.

### Description

- Render per-edge rounded white rectangles behind value text in `PayoffDirectedGraphPlotter.draw` so the numeric labels sit on a semi-opaque background and do not overlap arrows or the canvas (`src/monocycle_nash/visualization/payoff_graph.py`).
- Generate per-edge marker definitions and set the line stroke and marker fill to a color computed from the normalized payoff, so arrow color represents relative payoff magnitude as well as width/opacity.
- Add `_interpolate_color` helper to map normalized strengths to a blue→red gradient, and wire it into edge rendering logic.
- Update `tests/visualization/test_payoff_graph.py` to assert presence of rectangle labels, dynamic marker IDs, and high-value color output in the SVG.

### Testing

- Ran the focused test `uv run pytest tests/visualization/test_payoff_graph.py`, which passed (`2 passed`).
- Ran the full test suite with `uv run pytest`, which passed (`213 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991e09965c883308b4791cc9bcd6162)