### PR TITLE
Add runmeta CLI command to list projects

### DIFF
--- a/src/monocycle_nash/runmeta/cli.py
+++ b/src/monocycle_nash/runmeta/cli.py
@@ -50,6 +50,8 @@ def _build_parser() -> argparse.ArgumentParser:
     dp = sub.add_parser("delete-project")
     dp.add_argument("--project-id", required=True)
 
+    sub.add_parser("list-projects")
+
     l = sub.add_parser("list-runs")
     l.add_argument("--from", dest="from_at")
     l.add_argument("--to", dest="to_at")
@@ -139,6 +141,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             print("run_id\tproject_id\tstatus\tcreated_at")
             for row in rows:
                 print(f"{row.run_id}\t{row.project_id or ''}\t{row.status}\t{row.created_at}")
+            return 0
+
+        if args.command == "list-projects":
+            rows = projects.list_projects()
+            print("project_id\tproject_path\tcreated_at\tnote")
+            for row in rows:
+                print(f"{row.project_id}\t{row.project_path}\t{row.created_at}\t{row.note}")
             return 0
 
         return 1

--- a/src/monocycle_nash/runmeta/repositories.py
+++ b/src/monocycle_nash/runmeta/repositories.py
@@ -157,3 +157,7 @@ class ProjectsRepository:
         if row is None:
             return None
         return ProjectRecord(**dict(row))
+
+    def list_projects(self) -> list[ProjectRecord]:
+        rows = self.conn.execute("SELECT * FROM projects ORDER BY created_at DESC").fetchall()
+        return [ProjectRecord(**dict(r)) for r in rows]

--- a/tests/runmeta/test_cli.py
+++ b/tests/runmeta/test_cli.py
@@ -57,3 +57,15 @@ def test_cli_delete_run_with_files_removes_artifacts(tmp_path: Path, capsys, mon
     assert code == 0
     assert "deleted run" in capsys.readouterr().out
     assert not run_dir.exists()
+
+
+def test_cli_list_projects(tmp_path: Path, capsys) -> None:
+    db = tmp_path / "db.sqlite"
+    _seed(db)
+
+    code = main(["--db-path", str(db), "list-projects"])
+
+    assert code == 0
+    out = capsys.readouterr().out
+    assert "project_id" in out
+    assert "a	C:/a" in out

--- a/tests/runmeta/test_sqlite_repositories.py
+++ b/tests/runmeta/test_sqlite_repositories.py
@@ -39,3 +39,16 @@ def test_migration_and_repository_flow() -> None:
 
     listed = runs.list_runs(status="success", project_id="analysis-main")
     assert [r.run_id for r in listed] == [run_id]
+
+
+def test_projects_repository_list_projects() -> None:
+    conn = SQLiteConnectionFactory(":memory:").connect()
+    migrate(conn)
+    projects = ProjectsRepository(conn)
+
+    projects.add(project_id="a", project_path="C:/a", created_at="2024-01-01T00:00:00+09:00", note="")
+    projects.add(project_id="b", project_path="C:/b", created_at="2024-01-02T00:00:00+09:00", note="note")
+
+    rows = projects.list_projects()
+
+    assert [row.project_id for row in rows] == ["b", "a"]


### PR DESCRIPTION
### Motivation

- Provide a CLI way to list registered projects because `runmeta` already supports listing runs and managing projects, but lacked a `project` list command. 
- Make it easy to inspect projects from scripts and CI by emitting a simple tab-separated table.

### Description

- Added a new `list-projects` subcommand to the `runmeta` CLI in `src/monocycle_nash/runmeta/cli.py` that prints `project_id`, `project_path`, `created_at`, and `note`.
- Implemented `ProjectsRepository.list_projects()` in `src/monocycle_nash/runmeta/repositories.py` to return `ProjectRecord` rows ordered by `created_at` descending.
- Added tests exercising the new CLI behavior and repository ordering by updating `tests/runmeta/test_cli.py` and `tests/runmeta/test_sqlite_repositories.py`.

### Testing

- Ran the repository test suite for runmeta with `uv run pytest tests/runmeta` and all tests passed.
- Test run summary: `10 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994434a08608330a92476fb86bcecd7)