### PR TITLE
runmeta一覧のcreated_at表示からタイムゾーン表記を除去

### DIFF
--- a/tests/runmeta/test_cli.py
+++ b/tests/runmeta/test_cli.py
@@ -43,6 +43,9 @@ def test_cli_list_runs(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "run_id" in out
     assert "\tfail\t" in out
+    created_at = out.strip().splitlines()[1].split("\t")[-1]
+    assert len(created_at) == len("2000-01-01 00:00")
+    assert "+" not in created_at
 
 
 def test_cli_delete_run_with_files_removes_artifacts(tmp_path: Path, capsys, monkeypatch) -> None:
@@ -69,6 +72,9 @@ def test_cli_list_projects(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "project_id" in out
     assert "a	C:/a" in out
+    created_at = out.strip().splitlines()[1].split("\t")[2]
+    assert len(created_at) == len("2000-01-01 00:00")
+    assert "+" not in created_at
 
 
 def test_cli_list_runs_with_unassigned_project_filter(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
### Motivation
- runmeta の一覧表示（実験一覧・プロジェクト一覧）で `created_at` を表示する際、JST に揃えつつ表示を分単位の簡潔な形式にしたい。
- 内部の時刻管理は ISO 形式のまま維持しつつ、一覧出力時のみタイムゾーン表記（例: `+09:00`）を非表示にするための変更です。

### Description
- `src/monocycle_nash/runmeta/cli.py` に `_format_timestamp_for_list` を追加し、`datetime.fromisoformat(...).astimezone(JST).strftime("%Y-%m-%d %H:%M")` で分単位の JST 表示へ整形するようにしました。
- `list-runs` と `list-projects` の出力で `row.created_at` を直接表示する代わりに `_format_timestamp_for_list` を使うように変更しました。
- `tests/runmeta/test_cli.py` を更新して `list-runs` / `list-projects` 出力が `YYYY-MM-DD HH:MM` 形式で `+`（タイムゾーン表記）を含まないことを検証するようにしました.

### Testing
- 実行したテストは `uv run pytest` で、テストスイートは `222 passed`（警告 3 件）で成功しました。
- 変更対象の CLI 挙動に関するテスト `tests/runmeta/test_cli.py` は該当のアサーションを追加・更新して成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699449c54af08330b8afaa73e5c91b96)