### PR TITLE
Add runmeta CLI command to regenerate project run references

### DIFF
--- a/src/monocycle_nash/runmeta/cli.py
+++ b/src/monocycle_nash/runmeta/cli.py
@@ -12,6 +12,7 @@ from .artifact_store import RunArtifactStore
 from .clock import JST, now_jst_iso
 from .db import SQLiteConnectionFactory, migrate
 from .models import RunStatus
+from .project_refs import create_analysis_project_reference
 from .repositories import UNASSIGNED_PROJECT_ID, ProjectsRepository, RunsRepository
 
 DEFAULT_DB_PATH = Path(".runmeta/run_history.db")
@@ -67,6 +68,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "--project-id",
         help=f"project id filter. use {UNASSIGNED_PROJECT_ID} for runs without a linked project",
     )
+
+    r = sub.add_parser("regenerate-project-refs")
+    r.add_argument("--project-id", required=True)
+    r.add_argument("--result-base-dir", default="results")
 
     return parser
 
@@ -164,6 +169,27 @@ def main(argv: Sequence[str] | None = None) -> int:
                     f"{row.project_id}\t{row.project_path}\t"
                     f"{_format_timestamp_for_list(row.created_at)}\t{row.note}"
                 )
+            return 0
+
+        if args.command == "regenerate-project-refs":
+            project = projects.find(args.project_id)
+            if project is None:
+                print(f"project id {args.project_id} not found")
+                return 1
+            if not project.project_path:
+                print(f"project id {args.project_id} has empty project_path")
+                return 1
+
+            project_runs = runs.list_runs(project_id=args.project_id)
+            artifact_store = RunArtifactStore(Path(args.result_base_dir))
+            for run in project_runs:
+                create_analysis_project_reference(
+                    run_id=run.run_id,
+                    result_dir=artifact_store.run_dir(run.run_id),
+                    project_path=project.project_path,
+                    status=run.status,
+                )
+            print(f"regenerated {len(project_runs)} references for project {args.project_id}")
             return 0
 
         return 1

--- a/src/monocycle_nash/runmeta/project_refs.py
+++ b/src/monocycle_nash/runmeta/project_refs.py
@@ -1,0 +1,70 @@
+"""Helpers for creating per-project references to run output directories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+from .clock import now_jst_iso
+
+
+def create_analysis_project_reference(*, run_id: int, result_dir: Path, project_path: str | None, status: str) -> None:
+    if not project_path:
+        return
+
+    refs_dir = Path(project_path) / "experiment_refs"
+    refs_dir.mkdir(parents=True, exist_ok=True)
+
+    ref_dir = refs_dir / str(run_id)
+    _remove_existing_reference(ref_dir)
+
+    target_dir = result_dir.resolve()
+    try:
+        ref_dir.symlink_to(target_dir, target_is_directory=True)
+        _remove_existing_reference(refs_dir / f"{run_id}.txt")
+        return
+    except OSError:
+        pass
+
+    if _try_create_windows_junction(link_dir=ref_dir, target_dir=target_dir):
+        _remove_existing_reference(refs_dir / f"{run_id}.txt")
+        return
+
+    (refs_dir / f"{run_id}.txt").write_text(
+        "\n".join(
+            [
+                f"result_path={target_dir}",
+                f"created_at={now_jst_iso()}",
+                f"status={status}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _remove_existing_reference(path: Path) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+        return
+    shutil.rmtree(path)
+
+
+def _try_create_windows_junction(*, link_dir: Path, target_dir: Path) -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link_dir), str(target_dir)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, OSError):
+        return False
+

--- a/tests/entrypoints/test_common.py
+++ b/tests/entrypoints/test_common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import monocycle_nash.entrypoints.common as common_mod
+import monocycle_nash.runmeta.project_refs as project_refs_mod
 
 from monocycle_nash.entrypoints.common import (
     build_characters,
@@ -332,7 +333,7 @@ def test_prepare_run_session_writes_txt_when_symlink_and_junction_fail(tmp_path:
         raise OSError("symlink disabled")
 
     monkeypatch.setattr(Path, "symlink_to", _raise_symlink)
-    monkeypatch.setattr(common_mod, "_try_create_windows_junction", lambda **_: False)
+    monkeypatch.setattr(project_refs_mod, "_try_create_windows_junction", lambda **_: False)
 
     _, ctx, conn = prepare_run_session(setting, "python -m monocycle_nash.entrypoints.solve_payoff --run-config txt")
     conn.close()


### PR DESCRIPTION
### Motivation
- Provide a CLI operation to re-create `experiment_refs` links for all runs associated with a project so links can be regenerated on demand.
- Share and centralize the reference-creation logic so entrypoints and CLI behave identically (symlink, Windows junction, or txt fallback).
- Include run status in fallback txt records to preserve run metadata when linking is not possible.

### Description
- Added `src/monocycle_nash/runmeta/project_refs.py` with `create_analysis_project_reference` implementing symlink, Windows junction, and txt-fallback behavior and writing `status` in the txt file.
- Added `regenerate-project-refs` subcommand to the runmeta CLI in `src/monocycle_nash/runmeta/cli.py` with `--project-id` and `--result-base-dir` options to regenerate references for all runs of a project.
- Updated `prepare_run_session` in `src/monocycle_nash/entrypoints/common.py` to call the new `create_analysis_project_reference` helper with `status="running"` so entrypoints reuse the same logic.
- Added/updated tests to cover CLI regeneration and the fallback txt behavior in `tests/runmeta/test_cli.py` and `tests/entrypoints/test_common.py` and adjusted imports for test patching.

### Testing
- Ran `uv run pytest tests/runmeta/test_cli.py tests/entrypoints/test_common.py` and the targeted tests passed.
- Ran full test suite with `uv run pytest` and all tests passed (`223 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994523cb05c8330b0fb0908b02a7894)