### PR TITLE
docs: expand README overview for runmeta management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ uv run plot_characters --run-config baseline/janken_char_plot
 
 あわせて実行履歴が `.runmeta/run_history.db` に記録されます（設定で変更可能）。
 
+## 管理システムCLI
+
+本体コマンド（`solve_payoff` / `graph_payoff` / `plot_characters`）を通常実行した場合でも、
+実行履歴は管理システムにより自動でDBへ保存されます（既定: `.runmeta/run_history.db`）。
+
+また、`setting.analysis_project` を設定している場合は、runと考察用ディレクトリを結びつける参照リンク生成にも対応しています。
+管理システムCLI（`runmeta`）を使うと、これらの実行履歴・project情報の一覧確認や更新、参照の再生成を行えます。
+
+詳細な使い方は次のドキュメントに分離しています。
+
+- [`document/management/runmeta_cli.md`](document/management/runmeta_cli.md)
+
 ## 入力ファイルの準備方法
 
 `--run-config` で指定する文字列は、`data/run_config/<name>.toml`（拡張子省略）を指します。  

--- a/document/management/runmeta_cli.md
+++ b/document/management/runmeta_cli.md
@@ -1,0 +1,68 @@
+# runmeta CLI 使い方
+
+`runmeta` は、実行履歴DB（既定: `.runmeta/run_history.db`）を操作する管理用CLIです。  
+メインの解析コマンド（`solve_payoff` / `graph_payoff` / `plot_characters`）を補助する用途を想定しています。
+
+## 起動方法
+
+```bash
+uv run runmeta --help
+```
+
+DBの場所を切り替える場合は `--db-path` を付けます。
+
+```bash
+uv run runmeta --db-path .runmeta/run_history.db list-runs
+```
+
+## サブコマンド一覧
+
+- `list-runs`: 実行履歴を一覧表示
+- `update-run`: run の `status` / `note` / `project_id` を更新
+- `delete-run`: run を削除（`--with-files` で出力フォルダも削除）
+- `list-projects`: プロジェクト一覧を表示
+- `add-project`: プロジェクトを追加
+- `update-project`: プロジェクト情報を更新
+- `delete-project`: プロジェクトを削除
+- `regenerate-project-refs`: project に紐づく run の参照リンクを再生成
+
+## よく使う例
+
+### 実行履歴の確認
+
+```bash
+uv run runmeta list-runs
+uv run runmeta list-runs --status success
+uv run runmeta list-runs --project-id prototype
+```
+
+### run の更新・削除
+
+```bash
+uv run runmeta update-run --run-id 12 --status success --note "収束条件を見直し"
+uv run runmeta update-run --run-id 12 --project-id prototype
+uv run runmeta delete-run --run-id 12
+uv run runmeta delete-run --run-id 12 --with-files
+```
+
+### project の管理
+
+```bash
+uv run runmeta add-project --project-id prototype --project-path project_prototype --note "試験運用"
+uv run runmeta update-project --project-id prototype --note "メモ更新"
+uv run runmeta list-projects
+uv run runmeta delete-project --project-id prototype
+```
+
+### 参照リンクの再生成
+
+```bash
+uv run runmeta regenerate-project-refs --project-id prototype --result-base-dir results
+```
+
+## 補足
+
+- `runmeta` 実行時は必要に応じてマイグレーションが走り、DBスキーマを整えます。
+- `list-runs` / `list-projects` の時刻表示は JST（`YYYY-MM-DD HH:MM`）です。
+- `update-run` は `--status` `--note` `--project-id` のいずれか1つ以上が必須です。
+- `update-project` は `--project-path` か `--note` のどちらかが必須です。


### PR DESCRIPTION
### Motivation
- Make the README explicitly state that the management system is active during normal runs so users know run history is recorded automatically. 
- Explain at a high level that `setting.analysis_project` enables linking runs to analysis directories and that the `runmeta` CLI can inspect and manage those records.

### Description
- Replaced the terse README note with an expanded `## 管理システムCLI` section that documents automatic run history storage (default `.runmeta/run_history.db`) and project-link/reference behavior for `setting.analysis_project`.
- Added a dedicated guide at `document/management/runmeta_cli.md` containing `runmeta` invocation, subcommand list, common usage examples, and behavioral notes, while delegating detailed usage there.

### Testing
- Ran the test suite with `uv run pytest`, which completed successfully with `223 passed` and `3 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994573543a88330b637475a9bcea543)