### PR TITLE
Restrict payoff eigenvalue support to alternating matrices

### DIFF
--- a/src/monocycle_nash/entrypoints/solve_payoff.py
+++ b/src/monocycle_nash/entrypoints/solve_payoff.py
@@ -53,15 +53,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "divergence": divergence,
             },
         )
+
+        output_files = [
+            "output/equilibrium.json",
+            "output/pure_strategy.json",
+            "output/divergence.json",
+        ]
+        if matrix.is_alternating():
+            write_json(
+                out_dir / "eigenvalues.json",
+                {"eigenvalues": matrix.eigenvalues().tolist()},
+            )
+            output_files.append("output/eigenvalues.json")
+
         service.finish_success(
             ctx,
-            extra_meta={
-                "output_files": [
-                    "output/equilibrium.json",
-                    "output/pure_strategy.json",
-                    "output/divergence.json",
-                ]
-            },
+            extra_meta={"output_files": output_files},
         )
         return 0
     except Exception as exc:  # noqa: BLE001

--- a/src/monocycle_nash/matrix/base.py
+++ b/src/monocycle_nash/matrix/base.py
@@ -9,13 +9,13 @@ if TYPE_CHECKING:
 
 class PayoffMatrix(ABC):
     """利得行列の抽象基底クラス"""
-    
+
     @property
     @abstractmethod
     def matrix(self) -> np.ndarray:
         """利得行列のnumpy配列"""
         pass
-    
+
     @property
     @abstractmethod
     def size(self) -> int:
@@ -38,16 +38,30 @@ class PayoffMatrix(ABC):
     def labels(self) -> list[str]:
         """後方互換: 行プレイヤー側ラベル。"""
         return self.row_strategies.labels
-    
+
     @abstractmethod
     def solve_equilibrium(self) -> "MixedStrategy":
         """この行列に適した方法で均衡解を計算"""
         pass
-    
+
     def get_value(self, i: int, j: int) -> float:
         """行列の要素(i,j)を取得"""
         return self.matrix[i, j]
-    
+
+    def is_alternating(self, *, atol: float = 1e-8) -> bool:
+        """交代行列( A^T = -A ) かどうかを判定する。"""
+        matrix = np.asarray(self.matrix, dtype=float)
+        if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+            return False
+        return np.allclose(matrix + matrix.T, 0.0, atol=atol)
+
+    def eigenvalues(self, *, atol: float = 1e-8) -> np.ndarray:
+        """交代行列の固有値から、虚部の絶対値を実数配列で返す。"""
+        if not self.is_alternating(atol=atol):
+            raise ValueError("eigenvalues は交代行列の場合のみ利用できます")
+        values = np.linalg.eigvals(self.matrix)
+        return np.abs(np.imag(values))
+
     def __eq__(self, other: object) -> bool:
         """利得行列の等価判定"""
         if not isinstance(other, PayoffMatrix):

--- a/tests/entrypoints/test_solve_payoff.py
+++ b/tests/entrypoints/test_solve_payoff.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from monocycle_nash.entrypoints.solve_payoff import main
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+def _write_setting(data_dir: Path, tmp_path: Path) -> None:
+    _write(
+        data_dir / "setting" / "local.toml",
+        f'''
+        [runmeta]
+        sqlite_path = "{(tmp_path / '.runmeta' / 'run_history.db').as_posix()}"
+
+        [output]
+        base_dir = "{(tmp_path / 'result').as_posix()}"
+        ''',
+    )
+
+
+def test_solve_payoff_outputs_eigenvalues_for_alternating_matrix(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write(
+        data_dir / "run_config" / "baseline" / "rps3_solve.toml",
+        '''
+        matrix = "rps3"
+        setting = "local"
+        ''',
+    )
+    _write(
+        data_dir / "matrix" / "rps3" / "data.toml",
+        '''
+        matrix = [[0, 1, -1], [-1, 0, 1], [1, -1, 0]]
+        labels = ["rock", "paper", "scissors"]
+        ''',
+    )
+    _write_setting(data_dir, tmp_path)
+
+    code = main(["--run-config", "baseline/rps3_solve", "--data-dir", str(data_dir)])
+
+    assert code == 0
+
+    run_dirs = [x for x in (tmp_path / "result").iterdir() if x.is_dir()]
+    assert len(run_dirs) == 1
+
+    eigenvalues_path = run_dirs[0] / "output" / "eigenvalues.json"
+    assert eigenvalues_path.exists()
+
+    payload = json.loads(eigenvalues_path.read_text(encoding="utf-8"))
+    assert "eigenvalues" in payload
+    values = payload["eigenvalues"]
+    assert len(values) == 3
+    assert all(isinstance(v, float) for v in values)
+    assert all(v >= 0.0 for v in values)
+
+
+def test_solve_payoff_skips_eigenvalues_for_non_alternating_matrix(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write(
+        data_dir / "run_config" / "baseline" / "non_alt_solve.toml",
+        '''
+        matrix = "non_alt"
+        setting = "local"
+        ''',
+    )
+    _write(
+        data_dir / "matrix" / "non_alt" / "data.toml",
+        '''
+        matrix = [[0, 1], [0, 0]]
+        labels = ["a", "b"]
+        ''',
+    )
+    _write_setting(data_dir, tmp_path)
+
+    code = main(["--run-config", "baseline/non_alt_solve", "--data-dir", str(data_dir)])
+
+    assert code == 0
+
+    run_dirs = [x for x in (tmp_path / "result").iterdir() if x.is_dir()]
+    assert len(run_dirs) == 1
+
+    eigenvalues_path = run_dirs[0] / "output" / "eigenvalues.json"
+    assert not eigenvalues_path.exists()

--- a/tests/matrix/test_base.py
+++ b/tests/matrix/test_base.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from monocycle_nash.matrix.general import GeneralPayoffMatrix
+
+
+def test_eigenvalues_returns_imaginary_magnitudes_for_alternating_matrix() -> None:
+    matrix = np.array([[0.0, 2.0], [-2.0, 0.0]], dtype=float)
+    payoff = GeneralPayoffMatrix(matrix)
+
+    values = payoff.eigenvalues()
+
+    np.testing.assert_allclose(np.sort(values), np.array([2.0, 2.0]))
+
+
+def test_eigenvalues_raise_for_non_alternating_matrix() -> None:
+    matrix = np.array([[2.0, 0.0], [0.0, -1.0]], dtype=float)
+    payoff = GeneralPayoffMatrix(matrix)
+
+    with pytest.raises(ValueError, match="交代行列"):
+        payoff.eigenvalues()


### PR DESCRIPTION
### Motivation
- 固有値出力は交代行列（A^T = -A）でのみ意味を持つため、非交代行列での虚数処理や複素数取り扱いを避ける目的で仕様を明確化しました。 

### Description
- `PayoffMatrix` に `is_alternating()` を追加し、交代行列判定を行うようにしました. 
- `eigenvalues()` は交代行列でない場合に `ValueError` を投げるように変更し、交代行列の場合は固有値の虚部の絶対値（実数列）を返すようにしました (`np.abs(np.imag(...))`)。 
- エントリポイント `solve_payoff` は行列が交代行列のときのみ `output/eigenvalues.json` を出力するようにし、出力内容は実数配列 `{"eigenvalues": [...]}` にしました。 
- テストを追加・更新して、交代行列／非交代行列の挙動を `PayoffMatrix` API と `solve_payoff` エントリポイント双方で検証するようにしました (`tests/matrix/test_base.py` と `tests/entrypoints/test_solve_payoff.py`)。 

### Testing
- 実行したコマンド: `uv run pytest tests/matrix/test_base.py tests/entrypoints/test_solve_payoff.py`, 結果: 両テストは成功（`4 passed`）。
- 全テストスイート実行: `uv run pytest`, 結果: 全テストが成功し `227 passed, 3 warnings` でした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994718f1e9c83309cfad9631effe917)