### PR TITLE
Refine matrix approximation API to rely on type hints and update tests

### DIFF
--- a/src/monocycle_nash/matrix/__init__.py
+++ b/src/monocycle_nash/matrix/__init__.py
@@ -2,10 +2,22 @@ from .base import PayoffMatrix
 from .general import GeneralPayoffMatrix
 from .monocycle import MonocyclePayoffMatrix
 from .builder import PayoffMatrixBuilder
+from .approximation import (
+    PayoffMatrixApproximation,
+    MonocycleToGeneralApproximation,
+    PayoffMatrixDistance,
+    MaxElementDifferenceDistance,
+    ApproximationQualityEvaluator,
+)
 
 __all__ = [
     "PayoffMatrix",
     "GeneralPayoffMatrix",
     "MonocyclePayoffMatrix",
     "PayoffMatrixBuilder",
+    "PayoffMatrixApproximation",
+    "MonocycleToGeneralApproximation",
+    "PayoffMatrixDistance",
+    "MaxElementDifferenceDistance",
+    "ApproximationQualityEvaluator",
 ]

--- a/src/monocycle_nash/matrix/approximation.py
+++ b/src/monocycle_nash/matrix/approximation.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+import numpy as np
+
+from .base import PayoffMatrix
+from .general import GeneralPayoffMatrix
+from .monocycle import MonocyclePayoffMatrix
+
+InputMatrixT = TypeVar("InputMatrixT", bound=PayoffMatrix)
+ApproxMatrixT = TypeVar("ApproxMatrixT", bound=PayoffMatrix)
+ReferenceMatrixT = TypeVar("ReferenceMatrixT", bound=PayoffMatrix)
+
+
+class PayoffMatrixApproximation(ABC, Generic[InputMatrixT, ApproxMatrixT]):
+    """利得行列近似の抽象基底クラス。"""
+
+    @abstractmethod
+    def approximate(self, matrix: InputMatrixT) -> ApproxMatrixT:
+        raise NotImplementedError
+
+
+class MonocycleToGeneralApproximation(PayoffMatrixApproximation[MonocyclePayoffMatrix, GeneralPayoffMatrix]):
+    """MonocyclePayoffMatrix を GeneralPayoffMatrix へ変換する近似。"""
+
+    def approximate(self, matrix: MonocyclePayoffMatrix) -> GeneralPayoffMatrix:
+        return GeneralPayoffMatrix(
+            matrix=np.array(matrix.matrix, dtype=float, copy=True),
+            row_strategies=matrix.row_strategies,
+            col_strategies=matrix.col_strategies,
+        )
+
+
+class PayoffMatrixDistance(ABC, Generic[ApproxMatrixT, ReferenceMatrixT]):
+    """利得行列間距離の抽象基底クラス。"""
+
+    @abstractmethod
+    def calculate(self, left: ApproxMatrixT, right: ReferenceMatrixT) -> float:
+        raise NotImplementedError
+
+
+class MaxElementDifferenceDistance(PayoffMatrixDistance[PayoffMatrix, PayoffMatrix]):
+    """d(A, B) = max_ij |Aij - Bij|。"""
+
+    def calculate(self, left: PayoffMatrix, right: PayoffMatrix) -> float:
+        if left.matrix.shape != right.matrix.shape:
+            raise ValueError("matrix shapes must match for distance calculation")
+        return float(np.max(np.abs(left.matrix - right.matrix)))
+
+
+class ApproximationQualityEvaluator(Generic[InputMatrixT, ApproxMatrixT, ReferenceMatrixT]):
+    """近似器と距離指標を組み合わせて近似精度を評価する。"""
+
+    def __init__(
+        self,
+        approximation: PayoffMatrixApproximation[InputMatrixT, ApproxMatrixT],
+        distance: PayoffMatrixDistance[ApproxMatrixT, ReferenceMatrixT],
+    ):
+        self.approximation = approximation
+        self.distance = distance
+
+    def evaluate(self, source: InputMatrixT, reference: ReferenceMatrixT) -> float:
+        approximated = self.approximation.approximate(source)
+        return self.distance.calculate(approximated, reference)

--- a/tests/matrix/test_approximation.py
+++ b/tests/matrix/test_approximation.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+
+from monocycle_nash.character.domain import Character, MatchupVector
+from monocycle_nash.matrix.approximation import (
+    ApproximationQualityEvaluator,
+    MaxElementDifferenceDistance,
+    MonocycleToGeneralApproximation,
+)
+from monocycle_nash.matrix.builder import PayoffMatrixBuilder
+from monocycle_nash.matrix.general import GeneralPayoffMatrix
+
+
+@pytest.fixture
+def sample_monocycle_matrix():
+    characters = [
+        Character(1.0, MatchupVector(1.0, 0.0), label="A"),
+        Character(0.2, MatchupVector(0.0, 1.0), label="B"),
+        Character(0.8, MatchupVector(-1.0, 0.0), label="C"),
+    ]
+    return PayoffMatrixBuilder.from_characters(characters)
+
+
+def test_monocycle_to_general_approximation_returns_general_matrix(sample_monocycle_matrix):
+    approx = MonocycleToGeneralApproximation()
+
+    result = approx.approximate(sample_monocycle_matrix)
+
+    assert isinstance(result, GeneralPayoffMatrix)
+    assert np.array_equal(result.matrix, sample_monocycle_matrix.matrix)
+    assert result.row_strategies is sample_monocycle_matrix.row_strategies
+
+
+
+
+def test_max_element_difference_distance_rejects_shape_mismatch():
+    distance = MaxElementDifferenceDistance()
+    left = GeneralPayoffMatrix(np.array([[1.0, 2.0], [3.0, 4.0]]))
+    right = GeneralPayoffMatrix(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+
+    with pytest.raises(ValueError):
+        distance.calculate(left, right)
+
+
+def test_max_element_difference_distance_uses_sup_norm():
+    distance = MaxElementDifferenceDistance()
+    left = GeneralPayoffMatrix(np.array([[1.0, 4.0], [0.0, -1.0]]))
+    right = GeneralPayoffMatrix(np.array([[2.0, 2.0], [3.0, -2.0]]))
+
+    assert distance.calculate(left, right) == 3.0
+
+
+def test_approximation_quality_evaluator_combines_approximation_and_distance(sample_monocycle_matrix):
+    approximation = MonocycleToGeneralApproximation()
+    distance = MaxElementDifferenceDistance()
+    evaluator = ApproximationQualityEvaluator(approximation, distance)
+    reference = GeneralPayoffMatrix(sample_monocycle_matrix.matrix + 0.5)
+
+    quality = evaluator.evaluate(sample_monocycle_matrix, reference)
+
+    assert quality == pytest.approx(0.5)


### PR DESCRIPTION
### Motivation
- Remove runtime type-discrimination responsibility from the approximation/distance abstractions and express applicability via static type hints only. 
- Simplify abstraction surfaces to make implementations easier to reason about and to follow the requested policy of no `isinstance` runtime checks.
- Preserve necessary domain-level validation (matrix shape) that cannot be expressed via typing alone.

### Description
- Remove runtime `isinstance` checks from `PayoffMatrixApproximation` and `PayoffMatrixDistance`, making `approximate` and `calculate` abstract methods typed as `approximate(self, matrix: InputMatrixT) -> ApproxMatrixT` and `calculate(self, left: ApproxMatrixT, right: ReferenceMatrixT) -> float` respectively (file: `src/monocycle_nash/matrix/approximation.py`).
- Keep `MonocycleToGeneralApproximation` behavior but implement it against the new abstract API (file: `src/monocycle_nash/matrix/approximation.py`).
- Keep `MaxElementDifferenceDistance` but restrict it to only perform the domain-level check that matrices have matching shapes and compute the supremum norm (file: `src/monocycle_nash/matrix/approximation.py`).
- Export the new types from `monocycle_nash.matrix` by updating `src/monocycle_nash/matrix/__init__.py` to include the approximation-related classes.
- Update tests in `tests/matrix/test_approximation.py` to remove the runtime-type-rejection test and add a shape-mismatch `ValueError` test, plus keep existing behavioral tests aligned with the new API.

### Testing
- Ran `uv run pytest tests/matrix/test_approximation.py tests/matrix/test_builder.py tests/team/test_matrix_approx.py` and all tests passed; `14 passed` in the test run.
- The new/updated tests cover: `MonocycleToGeneralApproximation` conversion, `MaxElementDifferenceDistance` sup-norm behavior, and `ValueError` on shape mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3464b3d08330b48012b3230fafa1)