### PR TITLE
Add random skew-symmetric payoff matrix generation with acceptance conditions

### DIFF
--- a/src/monocycle_nash/matrix/__init__.py
+++ b/src/monocycle_nash/matrix/__init__.py
@@ -2,6 +2,7 @@ from .base import PayoffMatrix
 from .general import GeneralPayoffMatrix
 from .monocycle import MonocyclePayoffMatrix
 from .builder import PayoffMatrixBuilder
+from .random import RandomMatrixAcceptanceCondition, generate_random_skew_symmetric_matrix
 from .approximation import (
     PayoffMatrixApproximation,
     MonocycleToGeneralApproximation,
@@ -15,6 +16,8 @@ __all__ = [
     "GeneralPayoffMatrix",
     "MonocyclePayoffMatrix",
     "PayoffMatrixBuilder",
+    "RandomMatrixAcceptanceCondition",
+    "generate_random_skew_symmetric_matrix",
     "PayoffMatrixApproximation",
     "MonocycleToGeneralApproximation",
     "PayoffMatrixDistance",

--- a/src/monocycle_nash/matrix/builder.py
+++ b/src/monocycle_nash/matrix/builder.py
@@ -3,6 +3,10 @@ from typing import TYPE_CHECKING
 
 from .general import GeneralPayoffMatrix
 from .monocycle import MonocyclePayoffMatrix
+from .random import (
+    RandomMatrixAcceptanceCondition,
+    generate_random_skew_symmetric_matrix,
+)
 from ..character.domain import Character
 from ..strategy.domain import PureStrategySet
 from ..team.matrix_approx import TwoPlayerTeamMatrixCalculator
@@ -61,3 +65,25 @@ class PayoffMatrixBuilder:
             use_monocycle_formula=use_monocycle_formula,
         )
         return matrix_calculator.generate_matrix(teams)
+
+    @staticmethod
+    def from_random_matrix(
+        size: int,
+        low: float = -1.0,
+        high: float = 1.0,
+        acceptance_condition: RandomMatrixAcceptanceCondition | None = None,
+        *,
+        rng: np.random.Generator | None = None,
+        max_attempts: int = 10_000,
+        labels: list[str] | None = None,
+    ) -> GeneralPayoffMatrix:
+        """交代行列のランダム利得行列を生成する。"""
+        matrix = generate_random_skew_symmetric_matrix(
+            size=size,
+            low=low,
+            high=high,
+            acceptance_condition=acceptance_condition,
+            rng=rng,
+            max_attempts=max_attempts,
+        )
+        return GeneralPayoffMatrix(matrix, labels)

--- a/src/monocycle_nash/matrix/random.py
+++ b/src/monocycle_nash/matrix/random.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class RandomMatrixAcceptanceCondition(ABC):
+    """ランダム行列の採用可否を判定する抽象クラス。"""
+
+    @abstractmethod
+    def is_satisfied(self, matrix: np.ndarray) -> bool:
+        """条件を満たす場合はTrueを返す。"""
+
+
+def generate_random_skew_symmetric_matrix(
+    size: int,
+    low: float = -1.0,
+    high: float = 1.0,
+    acceptance_condition: RandomMatrixAcceptanceCondition | None = None,
+    *,
+    rng: np.random.Generator | None = None,
+    max_attempts: int = 10_000,
+) -> np.ndarray:
+    """
+    対角成分0・非対角成分が交代行列のランダム行列を生成する。
+
+    acceptance_condition が指定された場合は満たすまで再生成する。
+    """
+    if size <= 0:
+        raise ValueError("size は1以上である必要があります")
+    if high <= low:
+        raise ValueError("high は low より大きい必要があります")
+    if max_attempts <= 0:
+        raise ValueError("max_attempts は1以上である必要があります")
+
+    random = rng if rng is not None else np.random.default_rng()
+
+    for _ in range(max_attempts):
+        matrix = np.zeros((size, size), dtype=float)
+        upper_indices = np.triu_indices(size, k=1)
+        values = random.uniform(low, high, size=upper_indices[0].size)
+        matrix[upper_indices] = values
+        matrix[(upper_indices[1], upper_indices[0])] = -values
+
+        if acceptance_condition is None or acceptance_condition.is_satisfied(matrix):
+            return matrix
+
+    raise RuntimeError("指定された条件を満たす行列を生成できませんでした")
+

--- a/tests/matrix/test_random.py
+++ b/tests/matrix/test_random.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+
+from monocycle_nash.matrix import (
+    RandomMatrixAcceptanceCondition,
+    generate_random_skew_symmetric_matrix,
+)
+from monocycle_nash.matrix.builder import PayoffMatrixBuilder
+
+
+class RankFourCondition(RandomMatrixAcceptanceCondition):
+    def is_satisfied(self, matrix: np.ndarray) -> bool:
+        return int(np.linalg.matrix_rank(matrix)) == 4
+
+
+class NeverPassCondition(RandomMatrixAcceptanceCondition):
+    def is_satisfied(self, matrix: np.ndarray) -> bool:
+        return False
+
+
+def test_generate_random_skew_symmetric_matrix_defaults():
+    rng = np.random.default_rng(42)
+    matrix = generate_random_skew_symmetric_matrix(size=6, rng=rng)
+
+    assert matrix.shape == (6, 6)
+    np.testing.assert_allclose(np.diag(matrix), 0.0)
+    np.testing.assert_allclose(matrix + matrix.T, 0.0, atol=1e-12)
+    assert np.all(matrix[np.triu_indices(6, k=1)] >= -1.0)
+    assert np.all(matrix[np.triu_indices(6, k=1)] <= 1.0)
+
+
+def test_generate_random_skew_symmetric_matrix_with_acceptance_condition():
+    rng = np.random.default_rng(123)
+    matrix = generate_random_skew_symmetric_matrix(
+        size=5,
+        low=-0.5,
+        high=0.5,
+        acceptance_condition=RankFourCondition(),
+        rng=rng,
+        max_attempts=20_000,
+    )
+
+    assert int(np.linalg.matrix_rank(matrix)) == 4
+
+
+def test_generate_random_skew_symmetric_matrix_raises_when_condition_not_met():
+    with pytest.raises(RuntimeError):
+        generate_random_skew_symmetric_matrix(
+            size=3,
+            acceptance_condition=NeverPassCondition(),
+            max_attempts=10,
+        )
+
+
+def test_builder_from_random_matrix_creates_general_payoff_matrix():
+    matrix = PayoffMatrixBuilder.from_random_matrix(size=4)
+
+    assert matrix.matrix.shape == (4, 4)
+    np.testing.assert_allclose(np.diag(matrix.matrix), 0.0)
+    np.testing.assert_allclose(matrix.matrix + matrix.matrix.T, 0.0, atol=1e-12)


### PR DESCRIPTION
### Motivation
- Provide a simple facility to generate random payoff matrices for experiments where entries are sampled uniformly and matrices must be skew-symmetric (zero diagonal, antisymmetric off-diagonals).  
- Allow callers to optionally require a matrix to satisfy developer-defined acceptance criteria and regenerate until the criterion is met for simple experimental workflows.

### Description
- Add `RandomMatrixAcceptanceCondition` abstract class and `generate_random_skew_symmetric_matrix(...)` in `src/monocycle_nash/matrix/random.py` to produce matrices with zero diagonal and antisymmetric off-diagonals, sampling upper-triangular entries uniformly in `[low, high]` (defaults `-1.0` to `1.0`).
- Implement retry logic controlled by `max_attempts` and pluggable acceptance checks via `RandomMatrixAcceptanceCondition.is_satisfied`; raise `RuntimeError` if attempts exhaust.
- Expose a builder convenience API `PayoffMatrixBuilder.from_random_matrix(...)` that returns a `GeneralPayoffMatrix` from a generated random matrix, and export the new interfaces from `monocycle_nash.matrix`.
- Add unit tests `tests/matrix/test_random.py` that cover default generation, acceptance-condition success case, exhaustion failure, and builder integration.

### Testing
- Ran targeted tests with `uv run pytest tests/matrix/test_random.py tests/matrix/test_builder.py` and validated the new tests passed after fixing the acceptance target.  
- Ran full test suite with `uv run pytest` and confirmed all tests passed: `235 passed, 3 warnings`.
- New tests added: `tests/matrix/test_random.py` (all assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3b884df08330a48b44a6a129b1f9)