### PR TITLE
Unify graph config into single file and load per-entrypoint sections

### DIFF
--- a/data/graph/character/default/data.toml
+++ b/data/graph/character/default/data.toml
@@ -1,2 +1,0 @@
-canvas_size = 840
-margin = 90

--- a/data/graph/default/data.toml
+++ b/data/graph/default/data.toml
@@ -1,0 +1,7 @@
+[payoff]
+threshold = 0.0
+canvas_size = 840
+
+[character]
+canvas_size = 840
+margin = 90

--- a/data/graph/payoff/default/data.toml
+++ b/data/graph/payoff/default/data.toml
@@ -1,2 +1,0 @@
-threshold = 0.0
-canvas_size = 840

--- a/data/run_config/baseline/janken_char_plot.toml
+++ b/data/run_config/baseline/janken_char_plot.toml
@@ -1,3 +1,3 @@
 matrix = "janken_characters"
-graph = "character/default"
+graph = "default"
 setting = "local"

--- a/data/run_config/baseline/janken_graph.toml
+++ b/data/run_config/baseline/janken_graph.toml
@@ -1,3 +1,3 @@
 matrix = "janken_matrix"
-graph = "payoff/default"
+graph = "default"
 setting = "local"

--- a/src/monocycle_nash/entrypoints/graph_payoff.py
+++ b/src/monocycle_nash/entrypoints/graph_payoff.py
@@ -17,7 +17,12 @@ from .common import (
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser("graph_payoff").parse_args(argv)
-    matrix_data, graph_data, setting, _ = load_inputs(args.run_config, args.data_dir, require_graph=True)
+    matrix_data, graph_data, setting, _ = load_inputs(
+        args.run_config,
+        args.data_dir,
+        require_graph=True,
+        graph_section="payoff",
+    )
     matrix = build_matrix(matrix_data)
 
     if graph_data is None:

--- a/src/monocycle_nash/entrypoints/plot_characters.py
+++ b/src/monocycle_nash/entrypoints/plot_characters.py
@@ -10,7 +10,12 @@ from .common import build_characters, build_parser, has_matrix_input, load_input
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser("plot_characters").parse_args(argv)
-    matrix_data, graph_data, setting, _ = load_inputs(args.run_config, args.data_dir, require_graph=True)
+    matrix_data, graph_data, setting, _ = load_inputs(
+        args.run_config,
+        args.data_dir,
+        require_graph=True,
+        graph_section="character",
+    )
 
     if has_matrix_input(matrix_data):
         raise ValueError("plot_characters は matrix ではなく characters 入力が必須です")


### PR DESCRIPTION
### Motivation
- Consolidate separate graph configuration files so related graph settings live in a single TOML and entrypoints only load the section they need.
- Allow `plot_characters` and `graph_payoff` to depend only on their required graph settings to simplify management of graph config.

### Description
- Added a `graph_section` parameter to `load_inputs` and implemented `_select_graph_section` to extract a named section (e.g. `payoff` or `character`) from the loaded graph TOML, raising on missing/invalid sections.
- Updated `graph_payoff` to call `load_inputs(..., graph_section="payoff")` and `plot_characters` to call `load_inputs(..., graph_section="character")` so each entrypoint receives only its relevant graph config.
- Merged the old separate graph files into `data/graph/default/data.toml` containing `[payoff]` and `[character]` sections, and updated baseline run configs to reference `graph = "default"`.
- Updated `tests/entrypoints/test_common.py` to reflect the unified graph config and added a test that verifies requesting a missing graph section raises an error.

### Testing
- Ran the full test suite with `uv run pytest`, resulting in all tests passing: `236 passed, 3 warnings`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ac1bb780c833081a6b746a3c36b6f)