### PR TITLE
Add compare_approximation section to main run config

### DIFF
--- a/data/run_config/main.toml
+++ b/data/run_config/main.toml
@@ -1,4 +1,4 @@
-features = ["solve_payoff", "graph_payoff"]
+features = ["solve_payoff", "graph_payoff", "compare_approximation"]
 
 [shared]
 matrix = "janken_matrix"
@@ -8,6 +8,10 @@ setting = "local"
 
 [graph_payoff]
 graph = "default"
+
+[compare_approximation]
+approximation_setting = "default"
+reference_matrix = "janken_matrix"
 
 [plot_characters]
 matrix = "janken_characters"


### PR DESCRIPTION
### Motivation
- Enable a new feature to compare matrix approximations that needs its own input IDs while reusing shared `matrix`/`setting` from the main run config.

### Description
- Updated `data/run_config/main.toml` to add `compare_approximation` to the `features` array and added a `[compare_approximation]` section that defines `approximation_setting` and `reference_matrix` in snake_case.

### Testing
- Ran `uv run pytest` and all tests passed (`238 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3cd3d79083308c54dfd23e104992)