### PR TITLE
Add compare_payoff feature runner to main dispatch

### DIFF
--- a/src/monocycle_nash/equilibrium/compare_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/compare_payoff_app.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from monocycle_nash.loader.main_config import MainConfigLoader
+
+FEATURE_NAME = "compare_payoff"
+
+
+def run(config_loader: MainConfigLoader) -> int:
+    config_loader.load_inputs_for_feature(FEATURE_NAME)
+    return 0

--- a/src/monocycle_nash/main.py
+++ b/src/monocycle_nash/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from monocycle_nash.equilibrium.compare_payoff_app import run as run_compare_payoff
 from monocycle_nash.equilibrium.solve_payoff_app import run as run_solve_payoff
 from monocycle_nash.graph.graph_payoff_app import run as run_graph_payoff
 from monocycle_nash.graph.plot_characters_app import run as run_plot_characters
@@ -12,6 +13,7 @@ def main() -> int:
 
     runners = {
         "solve_payoff": run_solve_payoff,
+        "compare_payoff": run_compare_payoff,
         "graph_payoff": run_graph_payoff,
         "plot_characters": run_plot_characters,
     }

--- a/tests/entrypoints/test_main.py
+++ b/tests/entrypoints/test_main.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+import monocycle_nash.main as main_mod
+
+
+class _FakeConfigLoader:
+    def __init__(self, features: list[str]) -> None:
+        self._features = features
+
+    def load_features(self) -> list[str]:
+        return self._features
+
+
+def test_main_runs_compare_payoff_and_returns_non_zero_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_loader = _FakeConfigLoader(["compare_payoff"])
+    monkeypatch.setattr(main_mod, "MainConfigLoader", lambda: fake_loader)
+
+    called: list[_FakeConfigLoader] = []
+
+    def _fake_compare_run(config_loader: _FakeConfigLoader) -> int:
+        called.append(config_loader)
+        return 7
+
+    monkeypatch.setattr(main_mod, "run_compare_payoff", _fake_compare_run)
+
+    assert main_mod.main() == 7
+    assert called == [fake_loader]
+
+
+def test_main_raises_value_error_with_unsupported_feature_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    unsupported_feature = "compare_payoff_next"
+    monkeypatch.setattr(main_mod, "MainConfigLoader", lambda: _FakeConfigLoader([unsupported_feature]))
+
+    with pytest.raises(ValueError, match=unsupported_feature):
+        main_mod.main()


### PR DESCRIPTION
### Motivation
- Add a new "compare_payoff" feature entrypoint and ensure the main dispatcher supports it with the same return-code-based error handling as existing features.
- Make sure unsupported feature names produce a `ValueError` that includes the exact feature name for clearer diagnostics.

### Description
- Added `src/monocycle_nash/equilibrium/compare_payoff_app.py` implementing `FEATURE_NAME = "compare_payoff"` and `run(config_loader) -> int` which validates inputs via `load_inputs_for_feature` and returns `0` on success.
- Imported `run_compare_payoff` in `src/monocycle_nash/main.py` and registered the `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3cf2a5448330b81e0b5d53497bd5)