### PR TITLE
Add compare_approximation app with evaluation and entrypoint tests

### DIFF
--- a/src/monocycle_nash/approximation/__init__.py
+++ b/src/monocycle_nash/approximation/__init__.py
@@ -1,0 +1,3 @@
+from .compare_approximation_app import FEATURE_NAME, run
+
+__all__ = ["FEATURE_NAME", "run"]

--- a/src/monocycle_nash/approximation/compare_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_approximation_app.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import traceback
+
+from monocycle_nash.loader.data_loader import ExperimentDataLoader
+from monocycle_nash.loader.main_config import MainConfigLoader
+from monocycle_nash.loader.runtime_common import _to_toml, build_matrix, prepare_run_session, write_input_snapshots, write_json
+from monocycle_nash.matrix import ApproximationQualityEvaluator, MaxElementDifferenceDistance, MonocycleToGeneralApproximation
+
+
+FEATURE_NAME = "compare_approximation"
+
+
+def run(config_loader: MainConfigLoader) -> int:
+    loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
+    approximation_data = loaded.approximation_data
+    if approximation_data is None:
+        raise ValueError("approximation 設定が必要です")
+
+    service, ctx, conn = prepare_run_session(loaded.setting_data, f"uv run main ({FEATURE_NAME})")
+    try:
+        source_matrix_data, reference_matrix_data = _load_source_and_reference_matrices(config_loader, loaded.matrix_data, approximation_data)
+
+        write_input_snapshots(
+            service,
+            ctx.run_id,
+            matrix_data=source_matrix_data,
+            graph_data=None,
+            setting_data=loaded.setting_data,
+        )
+        input_dir = service.artifact_store.run_dir(ctx.run_id) / "input"
+        (input_dir / "reference_matrix.toml").write_text(_to_toml(reference_matrix_data), encoding="utf-8")
+        (input_dir / "approximation.toml").write_text(_to_toml(approximation_data), encoding="utf-8")
+
+        approximation = _build_approximation(approximation_data)
+        distance = _build_distance(approximation_data)
+        evaluator = ApproximationQualityEvaluator(approximation, distance)
+
+        source_matrix = build_matrix(source_matrix_data)
+        reference_matrix = build_matrix(reference_matrix_data)
+        score = evaluator.evaluate(source_matrix, reference_matrix)
+
+        write_json(
+            service.artifact_store.run_dir(ctx.run_id) / "output" / "approximation_quality.json",
+            {
+                "source_matrix": _resolve_matrix_name(approximation_data, key="source_matrix", default="<shared.matrix>"),
+                "reference_matrix": _resolve_matrix_name(approximation_data, key="reference_matrix", default="<shared.matrix>"),
+                "approximation": "MonocycleToGeneralApproximation",
+                "distance": "MaxElementDifferenceDistance",
+                "quality": score,
+            },
+        )
+
+        service.finish_success(ctx, extra_meta={"output_files": ["output/approximation_quality.json"]})
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        err = traceback.format_exc()
+        (service.artifact_store.run_dir(ctx.run_id) / "logs" / "stderr.log").write_text(err, encoding="utf-8")
+        service.finish_fail(ctx, extra_meta={"error": str(exc)})
+        return 1
+    finally:
+        conn.close()
+
+
+def _load_source_and_reference_matrices(
+    config_loader: MainConfigLoader,
+    default_matrix_data: dict,
+    approximation_data: dict,
+) -> tuple[dict, dict]:
+    base_data_dir = config_loader._main_config_path.parent.parent
+    exp_loader = ExperimentDataLoader(base_dir=base_data_dir)
+
+    source_name = _resolve_matrix_name(approximation_data, key="source_matrix")
+    reference_name = _resolve_matrix_name(approximation_data, key="reference_matrix")
+
+    source_matrix_data = exp_loader.load("matrix", source_name) if source_name is not None else default_matrix_data
+    reference_matrix_data = exp_loader.load("matrix", reference_name) if reference_name is not None else default_matrix_data
+    return source_matrix_data, reference_matrix_data
+
+
+def _build_approximation(approximation_data: dict) -> MonocycleToGeneralApproximation:
+    approx_name = _resolve_algorithm_name(approximation_data, kind="approximation")
+    if approx_name != "MonocycleToGeneralApproximation":
+        raise ValueError(f"未対応の approximation です: {approx_name}")
+    return MonocycleToGeneralApproximation()
+
+
+def _build_distance(approximation_data: dict) -> MaxElementDifferenceDistance:
+    distance_name = _resolve_algorithm_name(approximation_data, kind="distance")
+    if distance_name != "MaxElementDifferenceDistance":
+        raise ValueError(f"未対応の distance です: {distance_name}")
+    return MaxElementDifferenceDistance()
+
+
+def _resolve_algorithm_name(approximation_data: dict, *, kind: str) -> str:
+    candidates = [
+        approximation_data,
+        approximation_data.get("approximation") if isinstance(approximation_data.get("approximation"), dict) else None,
+        approximation_data.get("approxmation") if isinstance(approximation_data.get("approxmation"), dict) else None,
+    ]
+    for container in candidates:
+        if container is None:
+            continue
+        value = container.get(kind)
+        if isinstance(value, str) and value:
+            return value
+    if kind == "approximation":
+        return "MonocycleToGeneralApproximation"
+    return "MaxElementDifferenceDistance"
+
+
+def _resolve_matrix_name(approximation_data: dict, *, key: str, default: str | None = None) -> str | None:
+    value = approximation_data.get(key)
+    if value is None:
+        return default
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{key} は空でない文字列で指定してください")
+    return value
+

--- a/src/monocycle_nash/main.py
+++ b/src/monocycle_nash/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from monocycle_nash.approximation.compare_approximation_app import run as run_compare_approximation
 from monocycle_nash.equilibrium.compare_payoff_app import run as run_compare_payoff
 from monocycle_nash.equilibrium.solve_payoff_app import run as run_solve_payoff
 from monocycle_nash.graph.graph_payoff_app import run as run_graph_payoff
@@ -14,6 +15,7 @@ def main() -> int:
     runners = {
         "solve_payoff": run_solve_payoff,
         "compare_payoff": run_compare_payoff,
+        "compare_approximation": run_compare_approximation,
         "graph_payoff": run_graph_payoff,
         "plot_characters": run_plot_characters,
     }

--- a/tests/entrypoints/test_compare_approximation.py
+++ b/tests/entrypoints/test_compare_approximation.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from monocycle_nash.approximation.compare_approximation_app import run
+from monocycle_nash.loader.main_config import MainConfigLoader
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text.strip() + "\n", encoding="utf-8")
+
+
+def _write_setting(data_dir: Path, tmp_path: Path) -> None:
+    _write(
+        data_dir / "setting" / "local.toml",
+        f'''
+        [runmeta]
+        sqlite_path = "{(tmp_path / '.runmeta' / 'run_history.db').as_posix()}"
+
+        [output]
+        base_dir = "{(tmp_path / 'result').as_posix()}"
+        ''',
+    )
+
+
+def test_compare_approximation_writes_quality_json(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write(
+        data_dir / "run_config" / "main.toml",
+        '''
+        features = ["compare_approximation"]
+
+        [shared]
+        matrix = "source_chars"
+        setting = "local"
+
+        [compare_approximation]
+        approximation = "default"
+        ''',
+    )
+    _write(
+        data_dir / "matrix" / "source_chars" / "data.toml",
+        '''
+        characters = [
+          { label = "rock", p = 0.5, v = [1.0, 0.0] },
+          { label = "paper", p = 0.5, v = [-0.5, 0.8660254] },
+          { label = "scissors", p = 0.5, v = [-0.5, -0.8660254] }
+        ]
+        ''',
+    )
+    _write(
+        data_dir / "approximation" / "default" / "data.toml",
+        '''
+        source_matrix = "source_chars"
+        reference_matrix = "source_chars"
+
+        [approxmation]
+        approximation = "MonocycleToGeneralApproximation"
+        distance = "MaxElementDifferenceDistance"
+        ''',
+    )
+    _write_setting(data_dir, tmp_path)
+
+    code = run(MainConfigLoader(data_dir / "run_config" / "main.toml"))
+
+    assert code == 0
+
+    run_dirs = [x for x in (tmp_path / "result").iterdir() if x.is_dir()]
+    assert len(run_dirs) == 1
+
+    result_path = run_dirs[0] / "output" / "approximation_quality.json"
+    assert result_path.exists()
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["approximation"] == "MonocycleToGeneralApproximation"
+    assert payload["distance"] == "MaxElementDifferenceDistance"
+    assert payload["quality"] == 0.0
+
+
+def test_compare_approximation_returns_failure_code_for_invalid_config(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write(
+        data_dir / "run_config" / "main.toml",
+        '''
+        features = ["compare_approximation"]
+
+        [shared]
+        matrix = "source_chars"
+        setting = "local"
+
+        [compare_approximation]
+        approximation = "default"
+        ''',
+    )
+    _write(
+        data_dir / "matrix" / "source_chars" / "data.toml",
+        '''
+        characters = [
+          { label = "a", p = 1.0, v = [1.0, 0.0] },
+          { label = "b", p = 1.0, v = [0.0, 1.0] },
+          { label = "c", p = 1.0, v = [-1.0, 0.0] }
+        ]
+        ''',
+    )
+    _write(
+        data_dir / "approximation" / "default" / "data.toml",
+        '''
+        source_matrix = "source_chars"
+        reference_matrix = "source_chars"
+        distance = "UnsupportedDistance"
+        ''',
+    )
+    _write_setting(data_dir, tmp_path)
+
+    code = run(MainConfigLoader(data_dir / "run_config" / "main.toml"))
+
+    assert code == 1


### PR DESCRIPTION
### Motivation
- Add an entrypoint to evaluate approximation quality between a monocycle source and a reference matrix driven by run config so approximation algorithms and distance metrics can be validated in CI and runmeta flows.

### Description
- Introduce `src/monocycle_nash/approximation/compare_approximation_app.py` implementing `FEATURE_NAME = "compare_approximation"` and `run(config_loader)` that loads `approximation` config from `MainConfigLoader` and resolves source/reference matrices. 
- Use `MonocycleToGeneralApproximation` and `MaxElementDifferenceDistance` (selected/validated from config) and run `ApproximationQualityEvaluator.evaluate`, then write result JSON to `result/<run_id>/output/approximation_quality.json` and save input snapshots. 
- Mirror existing runmeta behavior by calling `prepare_run_session`, writing stderr on exception, invoking `service.finish_success`/`service.finish_fail`, and closing DB connections, and expose the module via `src/monocycle_nash/approximation/__init__.py`. 
- Register the new feature in `main` and add `tests/entrypoints/test_compare_approximation.py` to verify success output and failure on invalid config.

### Testing
- Ran targeted entrypoint tests with `uv run pytest tests/entrypoints/test_compare_approximation.py tests/entrypoints/test_main.py tests/entrypoints/test_solve_payoff.py` and they passed. 
- Ran full test suite with `uv run pytest` and all tests passed (`244 passed, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b3eb5e6e4833089f871f93cbfa74b)