### PR TITLE
Add dominant-eigenpair approximation for alternating payoff matrices

### DIFF
--- a/src/monocycle_nash/matrix/__init__.py
+++ b/src/monocycle_nash/matrix/__init__.py
@@ -6,6 +6,7 @@ from .random import RandomMatrixAcceptanceCondition, generate_random_skew_symmet
 from .approximation import (
     PayoffMatrixApproximation,
     MonocycleToGeneralApproximation,
+    DominantEigenpairMonocycleApproximation,
     PayoffMatrixDistance,
     MaxElementDifferenceDistance,
     ApproximationQualityEvaluator,
@@ -20,6 +21,7 @@ __all__ = [
     "generate_random_skew_symmetric_matrix",
     "PayoffMatrixApproximation",
     "MonocycleToGeneralApproximation",
+    "DominantEigenpairMonocycleApproximation",
     "PayoffMatrixDistance",
     "MaxElementDifferenceDistance",
     "ApproximationQualityEvaluator",

--- a/tests/matrix/test_approximation.py
+++ b/tests/matrix/test_approximation.py
@@ -6,6 +6,7 @@ from monocycle_nash.matrix.approximation import (
     ApproximationQualityEvaluator,
     MaxElementDifferenceDistance,
     MonocycleToGeneralApproximation,
+    DominantEigenpairMonocycleApproximation,
 )
 from monocycle_nash.matrix.builder import PayoffMatrixBuilder
 from monocycle_nash.matrix.general import GeneralPayoffMatrix
@@ -59,3 +60,36 @@ def test_approximation_quality_evaluator_combines_approximation_and_distance(sam
     quality = evaluator.evaluate(sample_monocycle_matrix, reference)
 
     assert quality == pytest.approx(0.5)
+
+
+def test_dominant_eigenpair_monocycle_approximation_extracts_largest_pair_component():
+    approximation = DominantEigenpairMonocycleApproximation()
+    matrix = np.array(
+        [
+            [0.0, -5.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, -2.0],
+            [0.0, 0.0, 2.0, 0.0],
+        ]
+    )
+    source = GeneralPayoffMatrix(matrix)
+
+    result = approximation.approximate(source)
+
+    expected = np.array(
+        [
+            [0.0, -5.0, 0.0, 0.0],
+            [5.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    assert np.allclose(result.matrix, expected, atol=1e-7)
+
+
+def test_dominant_eigenpair_monocycle_approximation_rejects_non_alternating_matrix():
+    approximation = DominantEigenpairMonocycleApproximation()
+    source = GeneralPayoffMatrix(np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+    with pytest.raises(ValueError):
+        approximation.approximate(source)


### PR DESCRIPTION
### Motivation
- 交代行列（`A^T = -A`）に対して，単相性モデルの特別ケースとして，絶対値が最大の純虚固有値±ペアに対応するランク2成分を抽出する近似器を実装するための変更です。
- 2×2 単相性理論へ落とし込む前処理や近似品質比較に利用できるよう，既存の行列近似モジュールへ追加します。

### Description
- `src/monocycle_nash/matrix/approximation.py` に `DominantEigenpairMonocycleApproximation` を追加し，固有分解で純虚固有値の絶対値が最大のペアを選び，対応する実部・虚部から直交基底 `q1,q2` を作り抗対称なランク2成分 `sigma*(q1⊗q2 - q2⊗q1)` を返す実装を行いました。
- 入力の正方性チェックと交代行列チェック（`is_alternating`）を行い，退化ケースでのエラー処理（固有値がほぼ0, ベクトル退化など）を追加しました。
- 新クラスをパッケージの公開 API に追加（`src/monocycle_nash/matrix/__init__.py`）しました。
- `tests/matrix/test_approximation.py` にテストを追加し，最大固有値ペアの成分抽出と非交代行列の入力バリデーションを検証するようにしました。

### Testing
- 実行コマンド: `uv run pytest tests/matrix/test_approximation.py`。
- 結果: テストスイートは成功し，該当テストは `6 passed` で終了しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bac7e3674833094145c012613c6f6)