### PR TITLE
Add EquilibriumUStrategyDifferenceDistance and wire it into comparison flow

### DIFF
--- a/src/monocycle_nash/approximation/compare_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_approximation_app.py
@@ -8,9 +8,11 @@ from monocycle_nash.loader.runtime_common import _to_toml, build_matrix, prepare
 from monocycle_nash.matrix import (
     ApproximationQualityEvaluator,
     DominantEigenpairMonocycleApproximation,
+    EquilibriumUStrategyDifferenceDistance,
     MaxElementDifferenceDistance,
     MonocycleToGeneralApproximation,
     PayoffMatrixApproximation,
+    PayoffMatrixDistance,
 )
 
 
@@ -52,7 +54,7 @@ def run(config_loader: MainConfigLoader) -> int:
                 "source_matrix": _resolve_matrix_name(approximation_data, key="source_matrix", default="<shared.matrix>"),
                 "reference_matrix": _resolve_matrix_name(approximation_data, key="reference_matrix", default="<shared.matrix>"),
                 "approximation": "MonocycleToGeneralApproximation",
-                "distance": "MaxElementDifferenceDistance",
+                "distance": distance.__class__.__name__,
                 "quality": score,
             },
         )
@@ -93,11 +95,13 @@ def _build_approximation(approximation_data: dict) -> PayoffMatrixApproximation:
     raise ValueError(f"未対応の approximation です: {approx_name}")
 
 
-def _build_distance(approximation_data: dict) -> MaxElementDifferenceDistance:
+def _build_distance(approximation_data: dict) -> PayoffMatrixDistance:
     distance_name = _resolve_algorithm_name(approximation_data, kind="distance")
-    if distance_name != "MaxElementDifferenceDistance":
-        raise ValueError(f"未対応の distance です: {distance_name}")
-    return MaxElementDifferenceDistance()
+    if distance_name == "MaxElementDifferenceDistance":
+        return MaxElementDifferenceDistance()
+    if distance_name == "EquilibriumUStrategyDifferenceDistance":
+        return EquilibriumUStrategyDifferenceDistance()
+    raise ValueError(f"未対応の distance です: {distance_name}")
 
 
 def _resolve_algorithm_name(approximation_data: dict, *, kind: str) -> str:

--- a/src/monocycle_nash/matrix/__init__.py
+++ b/src/monocycle_nash/matrix/__init__.py
@@ -9,6 +9,7 @@ from .approximation import (
     DominantEigenpairMonocycleApproximation,
     PayoffMatrixDistance,
     MaxElementDifferenceDistance,
+    EquilibriumUStrategyDifferenceDistance,
     ApproximationQualityEvaluator,
 )
 
@@ -24,5 +25,6 @@ __all__ = [
     "DominantEigenpairMonocycleApproximation",
     "PayoffMatrixDistance",
     "MaxElementDifferenceDistance",
+    "EquilibriumUStrategyDifferenceDistance",
     "ApproximationQualityEvaluator",
 ]


### PR DESCRIPTION
### Motivation
- Provide a new distance metric that measures the sup-norm of the expected payoff gap against the reference matrix's equilibrium mixed strategy to better capture strategic differences.  

### Description
- Implement `EquilibriumUStrategyDifferenceDistance` in `matrix/approximation.py` which computes `||(A-B)u||_∞` using the reference matrix's equilibrium `u` resolved via `SolverSelector` and added constructor injection for a `solver_selector`.  
- Export the new class in `matrix/__init__.py` so it is available to callers.  
- Update the compare app `compare_approximation_app.py` to recognize and instantiate `EquilibriumUStrategyDifferenceDistance` and to write the chosen distance class name into the output JSON.  
- Add unit and integration tests that exercise the new distance behavior and the end-to-end selection in the entrypoint.  

### Testing
- Ran unit tests in `tests/matrix/test_approximation.py` which include `test_equilibrium_u_strategy_difference_distance_*` and they passed.  
- Ran entrypoint test `tests/entrypoints/test_compare_approximation.py` including the new `test_compare_approximation_supports_equilibrium_u_strategy_distance` and it passed, verifying the output JSON contains `"distance": "EquilibriumUStrategyDifferenceDistance"` and expected quality value.  
- All added and existing automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f2c5440e0833085c06c843b6076d7)