### PR TITLE
Remove legacy baseline run_config artifacts and obsolete baseline-era tests

### DIFF
--- a/data/run_config/baseline/janken_char_plot.toml
+++ b/data/run_config/baseline/janken_char_plot.toml
@@ -1,2 +1,0 @@
-matrix = "janken_characters"
-graph = "default"

--- a/data/run_config/baseline/janken_graph.toml
+++ b/data/run_config/baseline/janken_graph.toml
@@ -1,3 +1,0 @@
-matrix = "extended_janken_characters"
-graph = "payoff/default"
-setting = "local"

--- a/data/run_config/baseline/janken_solve.toml
+++ b/data/run_config/baseline/janken_solve.toml
@@ -1,1 +1,0 @@
-# solve_payoff は graph を不要とする。

--- a/data/run_config/baseline/w_janken_graph.toml
+++ b/data/run_config/baseline/w_janken_graph.toml
@@ -1,3 +1,0 @@
-matrix = "weighted_janken_matrix"
-graph = "payoff/default"
-setting = "local"

--- a/tests/entrypoints/test_common.py
+++ b/tests/entrypoints/test_common.py
@@ -3,73 +3,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import monocycle_nash.loader.runtime_common as common_mod
 import monocycle_nash.runmeta.project_refs as project_refs_mod
 
 from monocycle_nash.loader.runtime_common import (
     build_characters,
     build_matrix,
-    load_inputs,
     prepare_run_session,
     write_input_snapshots,
 )
-
-
-def _write(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(text.strip() + "\n", encoding="utf-8")
-
-
-def test_load_inputs_from_run_config(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "rps3_graph.toml",
-        '''
-        matrix = "rps3"
-        graph = "default"
-        setting = "local"
-        ''',
-    )
-    _write(
-        tmp_path / "data" / "matrix" / "rps3" / "data.toml",
-        '''
-        matrix = [[0, 1, -1], [-1, 0, 1], [1, -1, 0]]
-        ''',
-    )
-    _write(
-        tmp_path / "data" / "graph" / "default" / "data.toml",
-        '''
-        [payoff]
-        threshold = 0.0
-        canvas_size = 840
-
-        [character]
-        canvas_size = 840
-        margin = 90
-        ''',
-    )
-    _write(
-        tmp_path / "data" / "setting" / "local.toml",
-        '''
-        [runmeta]
-        sqlite_path = ".runmeta/run_history.db"
-
-        [output]
-        base_dir = "result"
-        ''',
-    )
-
-    matrix, graph, setting, run_cfg = load_inputs(
-        "baseline/rps3_graph",
-        tmp_path / "data",
-        require_graph=True,
-        graph_section="payoff",
-    )
-
-    assert matrix["matrix"][0] == [0, 1, -1]
-    assert graph is not None
-    assert graph["canvas_size"] == 840
-    assert setting["output"]["base_dir"] == "result"
-    assert run_cfg.name == "rps3_graph.toml"
 
 
 def test_build_matrix_requires_exclusive_matrix_or_characters() -> None:
@@ -92,94 +33,6 @@ def test_build_matrix_from_characters_rejects_duplicate_labels() -> None:
 def test_build_characters_rejects_non_numeric_vector() -> None:
     with pytest.raises(ValueError, match="数値配列"):
         build_characters({"characters": [{"label": "a", "p": 1.0, "v": ["x", 0.0]}]})
-
-
-def test_load_inputs_requires_graph_when_entrypoint_needs_it(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "rps3_solve.toml",
-        '''
-        matrix = "rps3"
-        setting = "local"
-        ''',
-    )
-    _write(
-        tmp_path / "data" / "matrix" / "rps3" / "data.toml",
-        '''
-        matrix = [[0, 1, -1], [-1, 0, 1], [1, -1, 0]]
-        ''',
-    )
-    _write(
-        tmp_path / "data" / "setting" / "local.toml",
-        '''
-        [output]
-        base_dir = "result"
-        ''',
-    )
-
-    with pytest.raises(ValueError, match="run_config.graph"):
-        load_inputs("baseline/rps3_solve", tmp_path / "data", require_graph=True)
-
-
-def test_load_inputs_rejects_empty_run_config_reference(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "invalid.toml",
-        '''
-        matrix = ""
-        setting = "local"
-        ''',
-    )
-
-    with pytest.raises(ValueError, match="空でない文字列"):
-        load_inputs("baseline/invalid", tmp_path / "data", require_graph=False)
-
-
-def test_load_inputs_rejects_invalid_graph_type(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "invalid_graph.toml",
-        '''
-        matrix = "rps3"
-        graph = "default"
-        setting = "local"
-        ''',
-    )
-    _write(tmp_path / "data" / "matrix" / "rps3" / "data.toml", 'matrix = [[0, 1], [-1, 0]]')
-    _write(tmp_path / "data" / "graph" / "default" / "data.toml", '[payoff]\ncanvas_size = "large"')
-    _write(tmp_path / "data" / "setting" / "local.toml", '[output]\nbase_dir = "result"')
-
-    with pytest.raises(ValueError, match="graph.canvas_size"):
-        load_inputs("baseline/invalid_graph", tmp_path / "data", require_graph=True, graph_section="payoff")
-
-
-def test_load_inputs_requires_requested_graph_section(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "invalid_graph_section.toml",
-        '''
-        matrix = "rps3"
-        graph = "default"
-        setting = "local"
-        ''',
-    )
-    _write(tmp_path / "data" / "matrix" / "rps3" / "data.toml", 'matrix = [[0, 1], [-1, 0]]')
-    _write(tmp_path / "data" / "graph" / "default" / "data.toml", '[payoff]\ncanvas_size = 840')
-    _write(tmp_path / "data" / "setting" / "local.toml", '[output]\nbase_dir = "result"')
-
-    with pytest.raises(ValueError, match="graph.character"):
-        load_inputs("baseline/invalid_graph_section", tmp_path / "data", require_graph=True, graph_section="character")
-
-
-def test_load_inputs_rejects_invalid_setting_type(tmp_path: Path) -> None:
-    _write(
-        tmp_path / "data" / "run_config" / "baseline" / "invalid_setting.toml",
-        '''
-        matrix = "rps3"
-        setting = "local"
-        ''',
-    )
-    _write(tmp_path / "data" / "matrix" / "rps3" / "data.toml", 'matrix = [[0, 1], [-1, 0]]')
-    _write(tmp_path / "data" / "setting" / "local.toml", '[output]\nbase_dir = 123')
-
-    with pytest.raises(ValueError, match="setting.output.base_dir"):
-        load_inputs("baseline/invalid_setting", tmp_path / "data", require_graph=False)
 
 
 def test_prepare_run_session_creates_output_base_dir_run_folder(tmp_path: Path) -> None:

--- a/tests/entrypoints/test_solve_payoff.py
+++ b/tests/entrypoints/test_solve_payoff.py
@@ -28,13 +28,6 @@ def _write_setting(data_dir: Path, tmp_path: Path) -> None:
 def test_solve_payoff_outputs_eigenvalues_for_alternating_matrix(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     _write(
-        data_dir / "run_config" / "baseline" / "rps3_solve.toml",
-        '''
-        matrix = "rps3"
-        setting = "local"
-        ''',
-    )
-    _write(
         data_dir / "matrix" / "rps3" / "data.toml",
         '''
         matrix = [[0, 1, -1], [-1, 0, 1], [1, -1, 0]]
@@ -43,7 +36,13 @@ def test_solve_payoff_outputs_eigenvalues_for_alternating_matrix(tmp_path: Path)
     )
     _write_setting(data_dir, tmp_path)
 
-    (data_dir / "run_config" / "main.toml").write_text("features=[\"solve_payoff\"]\n[shared]\nmatrix=\"rps3\"\nsetting=\"local\"\n[solve_payoff]\n", encoding="utf-8")
+    _write(data_dir / "run_config" / "main.toml", """
+features=["solve_payoff"]
+[shared]
+matrix="rps3"
+setting="local"
+[solve_payoff]
+""")
     code = run(MainConfigLoader(data_dir / "run_config" / "main.toml"))
 
     assert code == 0
@@ -65,13 +64,6 @@ def test_solve_payoff_outputs_eigenvalues_for_alternating_matrix(tmp_path: Path)
 def test_solve_payoff_skips_eigenvalues_for_non_alternating_matrix(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     _write(
-        data_dir / "run_config" / "baseline" / "non_alt_solve.toml",
-        '''
-        matrix = "non_alt"
-        setting = "local"
-        ''',
-    )
-    _write(
         data_dir / "matrix" / "non_alt" / "data.toml",
         '''
         matrix = [[0, 1], [0, 0]]
@@ -80,7 +72,13 @@ def test_solve_payoff_skips_eigenvalues_for_non_alternating_matrix(tmp_path: Pat
     )
     _write_setting(data_dir, tmp_path)
 
-    (data_dir / "run_config" / "main.toml").write_text("features=[\"solve_payoff\"]\n[shared]\nmatrix=\"non_alt\"\nsetting=\"local\"\n[solve_payoff]\n", encoding="utf-8")
+    _write(data_dir / "run_config" / "main.toml", """
+features=["solve_payoff"]
+[shared]
+matrix="non_alt"
+setting="local"
+[solve_payoff]
+""")
     code = run(MainConfigLoader(data_dir / "run_config" / "main.toml"))
 
     assert code == 0


### PR DESCRIPTION
### Motivation

- The old `data/run_config/baseline/*` TOML files are not used by the current `main.toml`-driven execution flow and only confuse test/data maintenance.  
- Several entrypoint tests were exercising the legacy `baseline/...` run-config path rather than the current `data/run_config/main.toml` flow, so they were obsolete and added noise to the test surface.

### Description

- Deleted unused baseline run-config files under `data/run_config/baseline/` (`janken_char_plot.toml`, `janken_graph.toml`, `janken_solve.toml`, `w_janken_graph.toml`).  
- Removed legacy `load_inputs`-centric tests from `tests/entrypoints/test_common.py` and left the tests that validate current behavior such as `build_matrix`, `build_characters`, `prepare_run_session`, and `write_input_snapshots`.  
- Updated `tests/entrypoints/test_solve_payoff.py` to stop writing/depending on `baseline/*` run-config entries and instead create a `run_config/main.toml` in the test fixture via the test helper `_write`.  
- Cleaned up imports/usages related to the removed baseline tests so test fixtures always create required `run_config` directories before writing `main.toml`.

### Testing

- Ran `uv run pytest tests/entrypoints/test_common.py tests/entrypoints/test_solve_payoff.py` and the tests completed successfully.  
- Result: `16 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81c392f3483308fee655eeec9d1b6)