### PR TITLE
Add unlinked runmeta mode via `_null` analysis project id

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,12 @@ base_dir = "results"
 [analysis_project]
 project_id = "prototype"
 project_path = "project_prototype"
+# 試験実行で project と紐づけたくない場合は _null を指定
+# project_id = "_null"
 ```
+
+`analysis_project.project_id = "_null"` を指定すると、runmeta 上は `project_id = NULL` として登録され、
+プロジェクト連携（projects テーブル登録 / experiment_refs 生成）を行わない単発実行モードになります。
 
 最低限、`runmeta` と `output` を置いておくと運用しやすいです。
 

--- a/data/setting/local.toml
+++ b/data/setting/local.toml
@@ -5,5 +5,5 @@ sqlite_path = ".runmeta/run_history.db"
 base_dir = "results"
 
 [analysis_project]
-project_id="protype"
+project_id="prototype"
 project_path="project_protype" # 本来は絶対パスで考察用のフォルダを指定

--- a/document/input_loader/usecase_entrypoints.md
+++ b/document/input_loader/usecase_entrypoints.md
@@ -161,9 +161,11 @@ project_path = "C:\\analysis\\main"
 - `runmeta.sqlite_path`: run履歴 DB。
 - `output.base_dir`: 実行結果ルート（`result` を想定）。
 - `analysis_project.project_id`: run を紐づける考察プロジェクトID。
+  - `_null` を指定すると「非紐づけモード」になり、`runs.project_id` は `NULL` で保存される。
 - `analysis_project.project_path`: 考察プロジェクト実体パス。
 
 `analysis_project` は `run_result_management_spec.md` の `projects` テーブル登録・関連付け時に使用する。
+ただし `project_id = "_null"` 時は projects 登録や参照リンク生成を行わない。
 
 ---
 

--- a/src/monocycle_nash/loader/runtime_common.py
+++ b/src/monocycle_nash/loader/runtime_common.py
@@ -18,7 +18,7 @@ from monocycle_nash.runmeta.artifact_store import RunArtifactStore
 from monocycle_nash.runmeta.clock import now_jst_iso
 from monocycle_nash.runmeta.db import SQLiteConnectionFactory, migrate
 from monocycle_nash.runmeta.project_refs import create_analysis_project_reference
-from monocycle_nash.runmeta.repositories import ProjectsRepository, RunsRepository
+from monocycle_nash.runmeta.repositories import UNASSIGNED_PROJECT_ID, ProjectsRepository, RunsRepository
 from monocycle_nash.runmeta.service import RunSessionService
 from monocycle_nash.team.domain import Team
 from monocycle_nash.team.matrix_approx import ExactTeamPayoffCalculator
@@ -362,6 +362,7 @@ def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessi
     service = RunSessionService(runs_repository=runs, artifact_store=RunArtifactStore(output_root))
 
     project_id = project.get("project_id") if isinstance(project.get("project_id"), str) and project.get("project_id") else None
+    project_id = _resolve_analysis_project_id(project_id)
     project_path = project.get("project_path") if isinstance(project.get("project_path"), str) and project.get("project_path") else None
     effective_project_path = _ensure_project_linkage(projects, project_id=project_id, project_path=project_path)
 
@@ -376,6 +377,12 @@ def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessi
         status="running",
     )
     return service, ctx, conn
+
+
+def _resolve_analysis_project_id(project_id: str | None) -> str | None:
+    if project_id == UNASSIGNED_PROJECT_ID:
+        return None
+    return project_id
 
 
 def _ensure_project_linkage(

--- a/tests/entrypoints/test_common.py
+++ b/tests/entrypoints/test_common.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 import monocycle_nash.runmeta.project_refs as project_refs_mod
+from monocycle_nash.runmeta.repositories import UNASSIGNED_PROJECT_ID
 
 from monocycle_nash.loader.runtime_common import (
     build_characters,
@@ -195,6 +196,32 @@ def test_prepare_run_session_updates_existing_project_path(tmp_path: Path) -> No
     assert (new_project_root / "experiment_refs" / str(second_ctx.run_id)).exists() or (
         new_project_root / "experiment_refs" / f"{second_ctx.run_id}.txt"
     ).exists()
+
+
+def test_prepare_run_session_uses_unassigned_project_id_as_unlinked_mode(tmp_path: Path) -> None:
+    output_base = tmp_path / "result"
+    project_root = tmp_path / "analysis-main"
+    setting = {
+        "runmeta": {"sqlite_path": str(tmp_path / ".runmeta" / "run_history.db")},
+        "output": {"base_dir": str(output_base)},
+        "analysis_project": {
+            "project_id": UNASSIGNED_PROJECT_ID,
+            "project_path": str(project_root),
+        },
+    }
+
+    service, ctx, conn = prepare_run_session(setting, "uv run main (solve_payoff) --run-config x")
+    try:
+        run = service.runs_repository.find_by_id(ctx.run_id)
+        project = service.runs_repository.conn.execute("SELECT * FROM projects").fetchall()
+    finally:
+        conn.close()
+
+    assert run is not None
+    assert run.project_id is None
+    assert run.project_path is None
+    assert project == []
+    assert not (project_root / "experiment_refs").exists()
 
 
 def test_prepare_run_session_writes_txt_when_symlink_and_junction_fail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
### Motivation
- Provide a temporary/single-run mode that avoids linking runs to a projects row or creating `experiment_refs` so users can run quick experiments without polluting the projects table. 
- Allow the CLI/config to express this mode via an explicit pseudo project id value used by the CLI (`_null`).

### Description
- Treat `analysis_project.project_id == UNASSIGNED_PROJECT_ID` (value `"_null"`) as unlinked mode by normalizing it to `None` in `prepare_run_session` and importing `UNASSIGNED_PROJECT_ID` from `runmeta.repositories` (`src/monocycle_nash/loader/runtime_common.py`).
- Added helper `_resolve_analysis_project_id` to centralize the normalization logic (`src/monocycle_nash/loader/runtime_common.py`).
- Added an entrypoint test to verify unlinked behavior: runs get recorded with `project_id = NULL`, no `projects` row is created, and no `experiment_refs` directory is generated (`tests/entrypoints/test_common.py`).
- Updated documentation/examples to document `_null` as a one-off/unlinked execution mode (`README.md`, `document/input_loader/usecase_entrypoints.md`).
- Fixed a small sample config typo in `data/setting/local.toml` (`protype` -> `prototype`).

### Testing
- Ran the full test suite with `uv run pytest`, which completed successfully with all tests passing: `257 passed, 3 warnings`.
- The newly added test for unlinked mode is included in the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82d85a150833087462162a9aa2f07)