### PR TITLE
Add default approximation and random-matrix configs and new compare_random_approximation setting

### DIFF
--- a/data/approximation/default/data.toml
+++ b/data/approximation/default/data.toml
@@ -1,0 +1,4 @@
+# compare_approximation のデフォルト設定
+# source_matrix / reference_matrix 未指定時は main.toml の shared.matrix を使用
+approximation = "MonocycleToGeneralApproximation"
+distance = "MaxElementDifferenceDistance"

--- a/data/random_matrix/default/data.toml
+++ b/data/random_matrix/default/data.toml
@@ -1,0 +1,2 @@
+# compare_random_approximation のデフォルト乱数行列設定
+size = 4

--- a/data/run_config/main.toml
+++ b/data/run_config/main.toml
@@ -10,8 +10,11 @@ setting = "local"
 graph = "default"
 
 [compare_approximation]
-approximation_setting = "default"
-reference_matrix = "janken_matrix"
+approximation = "default"
+
+[compare_random_approximation]
+approximation = "default"
+random_matrix = "default"
 
 [plot_characters]
 matrix = "janken_characters"


### PR DESCRIPTION
### Motivation
- Standardize the approximation config key and add support for comparing approximation results against synthetic random matrices via a new `compare_random_approximation` section.
- Provide default parameter files so the approximation and random-matrix features have sensible defaults for local runs.

### Description
- Added `data/approximation/default/data.toml` with `approximation = "MonocycleToGeneralApproximation"` and `distance = "MaxElementDifferenceDistance"` as defaults.
- Added `data/random_matrix/default/data.toml` with `size = 4` as the default random matrix size.
- Updated `data/run_config/main.toml` to rename `approximation_setting` to `approximation`, removed the `reference_matrix` entry, and added a new `[compare_random_approximation]` section with `approximation = "default"` and `random_matrix = "default"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a833c6644083308d97eef8419df39f)