### PR TITLE
Share run ID/output directory when running multiple features

### DIFF
--- a/src/monocycle_nash/loader/runtime_common.py
+++ b/src/monocycle_nash/loader/runtime_common.py
@@ -4,6 +4,7 @@ import argparse
 import itertools
 import json
 import sqlite3
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,41 @@ from monocycle_nash.runmeta.repositories import UNASSIGNED_PROJECT_ID, ProjectsR
 from monocycle_nash.runmeta.service import RunSessionService
 from monocycle_nash.team.domain import Team
 from monocycle_nash.team.matrix_approx import ExactTeamPayoffCalculator
+
+
+@dataclass
+class _SharedRunState:
+    service: RunSessionService
+    ctx: Any
+    conn: sqlite3.Connection
+    failed: bool = False
+
+
+class _NoCloseConnection:
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def close(self) -> None:
+        return
+
+
+class _SharedRunSessionServiceProxy:
+    def __init__(self, service: RunSessionService, state: _SharedRunState) -> None:
+        self.artifact_store = service.artifact_store
+        self._state = state
+
+    def finish_success(self, ctx: Any, extra_meta: dict[str, Any] | None = None) -> None:
+        return
+
+    def finish_fail(self, ctx: Any, extra_meta: dict[str, Any] | None = None) -> None:
+        self._state.failed = True
+
+    def finish_killed(self, ctx: Any, extra_meta: dict[str, Any] | None = None) -> None:
+        self._state.failed = True
+
+
+_SHARED_RUN_MODE = False
+_SHARED_RUN_STATE: _SharedRunState | None = None
 
 
 def build_parser(prog: str) -> argparse.ArgumentParser:
@@ -346,7 +382,33 @@ def _optional_int(container: dict[str, Any], *, key: str) -> int | None:
     return value
 
 
+def set_shared_run_mode(enabled: bool) -> None:
+    global _SHARED_RUN_MODE
+    _SHARED_RUN_MODE = enabled
+
+
+def finalize_shared_run() -> None:
+    global _SHARED_RUN_STATE
+    state = _SHARED_RUN_STATE
+    if state is None:
+        return
+
+    try:
+        if state.failed:
+            state.service.finish_fail(state.ctx)
+        else:
+            state.service.finish_success(state.ctx)
+    finally:
+        state.conn.close()
+        _SHARED_RUN_STATE = None
+
+
 def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessionService, Any, sqlite3.Connection]:
+    global _SHARED_RUN_STATE
+    if _SHARED_RUN_MODE and _SHARED_RUN_STATE is not None:
+        shared = _SHARED_RUN_STATE
+        return _SharedRunSessionServiceProxy(shared.service, shared), shared.ctx, _NoCloseConnection(shared.conn)
+
     runmeta = setting.get("runmeta", {}) if isinstance(setting.get("runmeta"), dict) else {}
     output = setting.get("output", {}) if isinstance(setting.get("output"), dict) else {}
     project = setting.get("analysis_project", {}) if isinstance(setting.get("analysis_project"), dict) else {}
@@ -376,6 +438,11 @@ def prepare_run_session(setting: dict[str, Any], command: str) -> tuple[RunSessi
         project_path=effective_project_path,
         status="running",
     )
+
+    if _SHARED_RUN_MODE:
+        _SHARED_RUN_STATE = _SharedRunState(service=service, ctx=ctx, conn=conn)
+        return _SharedRunSessionServiceProxy(service, _SHARED_RUN_STATE), ctx, _NoCloseConnection(conn)
+
     return service, ctx, conn
 
 

--- a/src/monocycle_nash/main.py
+++ b/src/monocycle_nash/main.py
@@ -7,11 +7,14 @@ from monocycle_nash.equilibrium.solve_payoff_app import run as run_solve_payoff
 from monocycle_nash.graph.graph_payoff_app import run as run_graph_payoff
 from monocycle_nash.graph.plot_characters_app import run as run_plot_characters
 from monocycle_nash.loader.main_config import MainConfigLoader
+from monocycle_nash.loader.runtime_common import finalize_shared_run, set_shared_run_mode
 
 
 def main() -> int:
     config_loader = MainConfigLoader()
     features = config_loader.load_features()
+    shared_mode = len(features) > 1
+    set_shared_run_mode(shared_mode)
 
     runners = {
         "solve_payoff": run_solve_payoff,
@@ -22,14 +25,19 @@ def main() -> int:
         "plot_characters": run_plot_characters,
     }
 
-    for feature in features:
-        runner = runners.get(feature)
-        if runner is None:
-            raise ValueError(f"未対応の feature です: {feature}")
-        code = runner(config_loader)
-        if code != 0:
-            return code
-    return 0
+    try:
+        for feature in features:
+            runner = runners.get(feature)
+            if runner is None:
+                raise ValueError(f"未対応の feature です: {feature}")
+            code = runner(config_loader)
+            if code != 0:
+                return code
+        return 0
+    finally:
+        if shared_mode:
+            finalize_shared_run()
+            set_shared_run_mode(False)
 
 
 if __name__ == "__main__":

--- a/tests/entrypoints/test_main.py
+++ b/tests/entrypoints/test_main.py
@@ -51,3 +51,39 @@ def test_main_runs_compare_random_approximation(monkeypatch: pytest.MonkeyPatch)
 
     assert main_mod.main() == 0
     assert called == [fake_loader]
+
+
+def test_main_enables_shared_run_mode_for_multiple_features(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_loader = _FakeConfigLoader(["compare_payoff", "compare_random_approximation"])
+    monkeypatch.setattr(main_mod, "MainConfigLoader", lambda: fake_loader)
+
+    run_calls: list[str] = []
+    shared_mode_calls: list[bool] = []
+    finalize_calls = 0
+
+    def _fake_compare_run(config_loader: _FakeConfigLoader) -> int:
+        run_calls.append("compare_payoff")
+        assert config_loader is fake_loader
+        return 0
+
+    def _fake_random_run(config_loader: _FakeConfigLoader) -> int:
+        run_calls.append("compare_random_approximation")
+        assert config_loader is fake_loader
+        return 0
+
+    def _fake_set_shared_mode(enabled: bool) -> None:
+        shared_mode_calls.append(enabled)
+
+    def _fake_finalize() -> None:
+        nonlocal finalize_calls
+        finalize_calls += 1
+
+    monkeypatch.setattr(main_mod, "run_compare_payoff", _fake_compare_run)
+    monkeypatch.setattr(main_mod, "run_compare_random_approximation", _fake_random_run)
+    monkeypatch.setattr(main_mod, "set_shared_run_mode", _fake_set_shared_mode)
+    monkeypatch.setattr(main_mod, "finalize_shared_run", _fake_finalize)
+
+    assert main_mod.main() == 0
+    assert run_calls == ["compare_payoff", "compare_random_approximation"]
+    assert shared_mode_calls == [True, False]
+    assert finalize_calls == 1


### PR DESCRIPTION
## Summary
- add shared-run mode to `runtime_common.prepare_run_session` so multiple feature runs in a single `main` execution reuse the same run context/run id
- introduce a lightweight shared-session proxy so per-feature entrypoints can keep their current structure while avoiding premature DB finalize/connection close
- update `main` to enable shared mode only when two or more features are configured, and finalize the shared run once at the end
- add a regression test to ensure shared mode is enabled/finalized for multi-feature execution

## Testing
- `uv run pytest tests/entrypoints/test_main.py tests/entrypoints/test_common.py`
- `uv run pytest tests/entrypoints/test_solve_payoff.py tests/entrypoints/test_compare_approximation.py tests/entrypoints/test_compare_random_approximation.py tests/runmeta/test_artifact_store_and_service.py`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8380aa9388330aa6311a32c6c8280)