### PR TITLE
Introduce application ports and strong-typed feature config plumbing

### DIFF
--- a/src/monocycle_nash/application_ports.py
+++ b/src/monocycle_nash/application_ports.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ApproximationConfig:
+    source_matrix_name: str | None
+    reference_matrix_name: str | None
+    approximation_name: str
+    distance_name: str
+    raw_input: dict
+
+
+@dataclass(frozen=True)
+class RandomMatrixConfig:
+    size: int
+    generation_count: int
+    acceptance_condition: str
+    low: float
+    high: float
+    max_attempts: int
+    random_seed: int | None
+    raw_input: dict
+
+
+@dataclass(frozen=True)
+class PayoffGraphConfig:
+    threshold: float
+    canvas_size: int
+
+
+@dataclass(frozen=True)
+class CharacterGraphConfig:
+    canvas_size: int
+    margin: int
+
+
+@dataclass(frozen=True)
+class LoadedFeatureInputs:
+    matrix_data: dict
+    graph_config: PayoffGraphConfig | CharacterGraphConfig | None
+    approximation_config: ApproximationConfig | None
+    random_matrix_config: RandomMatrixConfig | None
+    setting_data: dict
+
+
+class FeatureWorkflowInputPort(Protocol):
+    def load_features(self) -> list[str]: ...
+
+    def load_inputs_for_feature(self, feature: str) -> LoadedFeatureInputs: ...
+
+    def load_matrix_data(self, matrix_name: str) -> dict: ...

--- a/src/monocycle_nash/approximation/compare_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_approximation_app.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+from monocycle_nash.application_ports import ApproximationConfig, FeatureWorkflowInputPort
 import traceback
 
-from monocycle_nash.loader.data_loader import ExperimentDataLoader
-from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import _to_toml, build_matrix, prepare_run_session, write_input_snapshots, write_json
 from monocycle_nash.matrix import (
     ApproximationQualityEvaluator,
@@ -20,15 +19,15 @@ from monocycle_nash.matrix import (
 FEATURE_NAME = "compare_approximation"
 
 
-def run(config_loader: MainConfigLoader) -> int:
+def run(config_loader: FeatureWorkflowInputPort) -> int:
     loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
-    approximation_data = loaded.approximation_data
-    if approximation_data is None:
+    approximation_config = loaded.approximation_config
+    if approximation_config is None:
         raise ValueError("approximation 設定が必要です")
 
     service, ctx, conn = prepare_run_session(loaded.setting_data, f"uv run main ({FEATURE_NAME})")
     try:
-        source_matrix_data, reference_matrix_data = _load_source_and_reference_matrices(config_loader, loaded.matrix_data, approximation_data)
+        source_matrix_data, reference_matrix_data = _load_source_and_reference_matrices(config_loader, loaded.matrix_data, approximation_config)
 
         write_input_snapshots(
             service,
@@ -39,10 +38,10 @@ def run(config_loader: MainConfigLoader) -> int:
         )
         input_dir = service.artifact_store.run_dir(ctx.run_id) / "input"
         (input_dir / "reference_matrix.toml").write_text(_to_toml(reference_matrix_data), encoding="utf-8")
-        (input_dir / "approximation.toml").write_text(_to_toml(approximation_data), encoding="utf-8")
+        (input_dir / "approximation.toml").write_text(_to_toml(approximation_config.raw_input), encoding="utf-8")
 
-        approximation = _build_approximation(approximation_data)
-        distance = _build_distance(approximation_data)
+        approximation = _build_approximation(approximation_config.approximation_name)
+        distance = _build_distance(approximation_config.distance_name)
         evaluator = ApproximationQualityEvaluator(approximation, distance)
 
         source_matrix = build_matrix(source_matrix_data)
@@ -52,8 +51,8 @@ def run(config_loader: MainConfigLoader) -> int:
         write_json(
             service.artifact_store.run_dir(ctx.run_id) / "output" / "approximation_quality.json",
             {
-                "source_matrix": _resolve_matrix_name(approximation_data, key="source_matrix", default="<shared.matrix>"),
-                "reference_matrix": _resolve_matrix_name(approximation_data, key="reference_matrix", default="<shared.matrix>"),
+                "source_matrix": approximation_config.source_matrix_name or "<shared.matrix>",
+                "reference_matrix": approximation_config.reference_matrix_name or "<shared.matrix>",
                 "approximation": approximation.__class__.__name__,
                 "distance": distance.__class__.__name__,
                 "quality": score,
@@ -72,23 +71,19 @@ def run(config_loader: MainConfigLoader) -> int:
 
 
 def _load_source_and_reference_matrices(
-    config_loader: MainConfigLoader,
+    config_loader: FeatureWorkflowInputPort,
     default_matrix_data: dict,
-    approximation_data: dict,
+    approximation_config: ApproximationConfig,
 ) -> tuple[dict, dict]:
-    base_data_dir = config_loader._main_config_path.parent.parent
-    exp_loader = ExperimentDataLoader(base_dir=base_data_dir)
+    source_name = approximation_config.source_matrix_name
+    reference_name = approximation_config.reference_matrix_name
 
-    source_name = _resolve_matrix_name(approximation_data, key="source_matrix")
-    reference_name = _resolve_matrix_name(approximation_data, key="reference_matrix")
-
-    source_matrix_data = exp_loader.load("matrix", source_name) if source_name is not None else default_matrix_data
-    reference_matrix_data = exp_loader.load("matrix", reference_name) if reference_name is not None else default_matrix_data
+    source_matrix_data = config_loader.load_matrix_data(source_name) if source_name is not None else default_matrix_data
+    reference_matrix_data = config_loader.load_matrix_data(reference_name) if reference_name is not None else default_matrix_data
     return source_matrix_data, reference_matrix_data
 
 
-def _build_approximation(approximation_data: dict) -> PayoffMatrixApproximation:
-    approx_name = _resolve_algorithm_name(approximation_data, kind="approximation")
+def _build_approximation(approx_name: str) -> PayoffMatrixApproximation:
     if approx_name == "MonocycleToGeneralApproximation":
         return MonocycleToGeneralApproximation()
     if approx_name == "DominantEigenpairMonocycleApproximation":
@@ -98,37 +93,11 @@ def _build_approximation(approximation_data: dict) -> PayoffMatrixApproximation:
     raise ValueError(f"未対応の approximation です: {approx_name}")
 
 
-def _build_distance(approximation_data: dict) -> PayoffMatrixDistance:
-    distance_name = _resolve_algorithm_name(approximation_data, kind="distance")
+def _build_distance(distance_name: str) -> PayoffMatrixDistance:
     if distance_name == "MaxElementDifferenceDistance":
         return MaxElementDifferenceDistance()
     if distance_name == "EquilibriumUStrategyDifferenceDistance":
         return EquilibriumUStrategyDifferenceDistance()
     raise ValueError(f"未対応の distance です: {distance_name}")
 
-
-def _resolve_algorithm_name(approximation_data: dict, *, kind: str) -> str:
-    candidates = [
-        approximation_data,
-        approximation_data.get("approximation") if isinstance(approximation_data.get("approximation"), dict) else None,
-        approximation_data.get("approxmation") if isinstance(approximation_data.get("approxmation"), dict) else None,
-    ]
-    for container in candidates:
-        if container is None:
-            continue
-        value = container.get(kind)
-        if isinstance(value, str) and value:
-            return value
-    if kind == "approximation":
-        return "MonocycleToGeneralApproximation"
-    return "MaxElementDifferenceDistance"
-
-
-def _resolve_matrix_name(approximation_data: dict, *, key: str, default: str | None = None) -> str | None:
-    value = approximation_data.get(key)
-    if value is None:
-        return default
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{key} は空でない文字列で指定してください")
-    return value
 

--- a/src/monocycle_nash/approximation/compare_random_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_random_approximation_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from monocycle_nash.application_ports import FeatureWorkflowInputPort, RandomMatrixConfig
 import traceback
 from dataclasses import asdict, dataclass
 from typing import Any
@@ -8,7 +9,6 @@ import numpy as np
 
 from monocycle_nash.approximation.compare_approximation_app import _build_approximation, _build_distance
 from monocycle_nash.approximation.random_experiment_domain import ApproximationQualityStatistics, ApproximationQualitySummary
-from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import (
     _to_toml,
     build_matrix,
@@ -43,13 +43,13 @@ class RankAtLeastFourCondition(RandomMatrixAcceptanceCondition):
         return int(np.linalg.matrix_rank(matrix)) >= 4
 
 
-def run(config_loader: MainConfigLoader) -> int:
+def run(config_loader: FeatureWorkflowInputPort) -> int:
     loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
-    approximation_data = loaded.approximation_data
-    random_matrix_data = loaded.random_matrix_data
-    if approximation_data is None:
+    approximation_config = loaded.approximation_config
+    random_matrix_config = loaded.random_matrix_config
+    if approximation_config is None:
         raise ValueError("approximation 設定が必要です")
-    if random_matrix_data is None:
+    if random_matrix_config is None:
         raise ValueError("random_matrix 設定が必要です")
 
     service, ctx, conn = prepare_run_session(loaded.setting_data, f"uv run main ({FEATURE_NAME})")
@@ -62,14 +62,14 @@ def run(config_loader: MainConfigLoader) -> int:
             setting_data=loaded.setting_data,
         )
         input_dir = service.artifact_store.run_dir(ctx.run_id) / "input"
-        (input_dir / "approximation.toml").write_text(_to_toml(approximation_data), encoding="utf-8")
-        (input_dir / "random_matrix.toml").write_text(_to_toml(random_matrix_data), encoding="utf-8")
+        (input_dir / "approximation.toml").write_text(_to_toml(approximation_config.raw_input), encoding="utf-8")
+        (input_dir / "random_matrix.toml").write_text(_to_toml(random_matrix_config.raw_input), encoding="utf-8")
 
-        approximation = _build_approximation(approximation_data)
-        distance = _build_distance(approximation_data)
+        approximation = _build_approximation(approximation_config.approximation_name)
+        distance = _build_distance(approximation_config.distance_name)
         evaluator = ApproximationQualityEvaluator(approximation, distance)
 
-        generation_cfg = _parse_random_generation_config(random_matrix_data)
+        generation_cfg = _parse_random_generation_config(random_matrix_config)
         rng = np.random.default_rng(generation_cfg.random_seed)
 
         statistics = ApproximationQualityStatistics()
@@ -84,7 +84,7 @@ def run(config_loader: MainConfigLoader) -> int:
             )
             source = build_matrix({"matrix": raw_matrix.tolist()})
             score = evaluator.evaluate(source, source)
-            parameters = approximation.quality_parameters(source, config=approximation_data)
+            parameters = approximation.quality_parameters(source, config=approximation_config.raw_input)
             statistics.add(score, parameters=parameters)
 
         overall = statistics.summarize()
@@ -147,35 +147,22 @@ def _condition_keyword(condition: RandomMatrixAcceptanceCondition | None) -> str
     raise ValueError("未対応の acceptance_condition です")
 
 
-def _parse_random_generation_config(config: dict) -> RandomGenerationConfig:
-    size = _required_int(config, key="size", default=None)
-    generation_count = _required_int(config, key="generation_count", default=100)
-    low = _required_float(config, key="low", default=-1.0)
-    high = _required_float(config, key="high", default=1.0)
-    max_attempts = _required_int(config, key="max_attempts", default=10_000)
-    random_seed = _optional_int(config, key="random_seed")
+def _parse_random_generation_config(config: RandomMatrixConfig) -> RandomGenerationConfig:
+    acceptance_condition = _build_acceptance_condition(config.acceptance_condition)
 
-    condition_keyword = config.get("acceptance_condition")
-    if condition_keyword is None:
-        condition_keyword = ""
-    if not isinstance(condition_keyword, str):
-        raise ValueError("random_matrix.acceptance_condition は文字列で指定してください")
-
-    acceptance_condition = _build_acceptance_condition(condition_keyword)
-
-    if size <= 0:
+    if config.size <= 0:
         raise ValueError("random_matrix.size は1以上で指定してください")
-    if generation_count <= 0:
+    if config.generation_count <= 0:
         raise ValueError("random_matrix.generation_count は1以上で指定してください")
 
     return RandomGenerationConfig(
-        size=size,
-        generation_count=generation_count,
+        size=config.size,
+        generation_count=config.generation_count,
         acceptance_condition=acceptance_condition,
-        low=low,
-        high=high,
-        max_attempts=max_attempts,
-        random_seed=random_seed,
+        low=config.low,
+        high=config.high,
+        max_attempts=config.max_attempts,
+        random_seed=config.random_seed,
     )
 
 
@@ -189,24 +176,3 @@ def _build_acceptance_condition(keyword: str) -> RandomMatrixAcceptanceCondition
     raise ValueError(f"未対応の random_matrix.acceptance_condition です: {keyword}")
 
 
-def _required_int(config: dict, *, key: str, default: int | None) -> int:
-    raw = config.get(key, default)
-    if not isinstance(raw, int):
-        raise ValueError(f"random_matrix.{key} は整数で指定してください")
-    return raw
-
-
-def _optional_int(config: dict, *, key: str) -> int | None:
-    raw = config.get(key)
-    if raw is None:
-        return None
-    if not isinstance(raw, int):
-        raise ValueError(f"random_matrix.{key} は整数で指定してください")
-    return raw
-
-
-def _required_float(config: dict, *, key: str, default: float) -> float:
-    raw = config.get(key, default)
-    if not isinstance(raw, (int, float)):
-        raise ValueError(f"random_matrix.{key} は数値で指定してください")
-    return float(raw)

--- a/src/monocycle_nash/equilibrium/compare_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/compare_payoff_app.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from monocycle_nash.loader.main_config import MainConfigLoader
+from monocycle_nash.application_ports import FeatureWorkflowInputPort
+
 
 FEATURE_NAME = "compare_payoff"
 
 
-def run(config_loader: MainConfigLoader) -> int:
+def run(config_loader: FeatureWorkflowInputPort) -> int:
     config_loader.load_inputs_for_feature(FEATURE_NAME)
     return 0

--- a/src/monocycle_nash/equilibrium/solve_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/solve_payoff_app.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from monocycle_nash.application_ports import FeatureWorkflowInputPort
 import traceback
 
 import numpy as np
 
-from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import build_matrix, prepare_run_session, write_input_snapshots, write_json
 from monocycle_nash.solver.selector import SolverSelector
 
@@ -12,7 +12,7 @@ from monocycle_nash.solver.selector import SolverSelector
 FEATURE_NAME = "solve_payoff"
 
 
-def run(config_loader: MainConfigLoader) -> int:
+def run(config_loader: FeatureWorkflowInputPort) -> int:
     loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
     matrix = build_matrix(loaded.matrix_data)
 

--- a/src/monocycle_nash/graph/graph_payoff_app.py
+++ b/src/monocycle_nash/graph/graph_payoff_app.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from monocycle_nash.application_ports import FeatureWorkflowInputPort
 import traceback
 
-from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import build_matrix, prepare_run_session, write_input_snapshots
 from monocycle_nash.visualization import PayoffDirectedGraphPlotter
 
@@ -10,15 +10,15 @@ from monocycle_nash.visualization import PayoffDirectedGraphPlotter
 FEATURE_NAME = "graph_payoff"
 
 
-def run(config_loader: MainConfigLoader) -> int:
-    loaded = config_loader.load_inputs_for_feature(FEATURE_NAME, graph_section="payoff")
+def run(config_loader: FeatureWorkflowInputPort) -> int:
+    loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
     matrix = build_matrix(loaded.matrix_data)
-    graph_data = loaded.graph_data
-    if graph_data is None:
+    graph_config = loaded.graph_config
+    if graph_config is None:
         raise ValueError("graph 設定が必要です")
 
-    threshold = float(graph_data.get("threshold", 0.0))
-    canvas_size = int(graph_data.get("canvas_size", 840))
+    threshold = graph_config.threshold
+    canvas_size = graph_config.canvas_size
 
     service, ctx, conn = prepare_run_session(loaded.setting_data, f"uv run main ({FEATURE_NAME})")
     try:
@@ -26,7 +26,7 @@ def run(config_loader: MainConfigLoader) -> int:
             service,
             ctx.run_id,
             matrix_data=loaded.matrix_data,
-            graph_data=graph_data,
+            graph_data={"threshold": threshold, "canvas_size": canvas_size},
             setting_data=loaded.setting_data,
         )
         out_file = service.artifact_store.run_dir(ctx.run_id) / "output" / "edge_graph.svg"

--- a/src/monocycle_nash/graph/plot_characters_app.py
+++ b/src/monocycle_nash/graph/plot_characters_app.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from monocycle_nash.application_ports import FeatureWorkflowInputPort
 import traceback
 
-from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import (
     build_characters,
     has_matrix_input,
@@ -15,15 +15,17 @@ from monocycle_nash.visualization import CharacterVectorGraphPlotter
 FEATURE_NAME = "plot_characters"
 
 
-def run(config_loader: MainConfigLoader) -> int:
-    loaded = config_loader.load_inputs_for_feature(FEATURE_NAME, graph_section="character")
+def run(config_loader: FeatureWorkflowInputPort) -> int:
+    loaded = config_loader.load_inputs_for_feature(FEATURE_NAME)
     if has_matrix_input(loaded.matrix_data):
         raise ValueError("plot_characters は matrix ではなく characters 入力が必須です")
     characters = build_characters(loaded.matrix_data)
-    graph_data = loaded.graph_data or {}
+    graph_config = loaded.graph_config
+    if graph_config is None:
+        raise ValueError("graph 設定が必要です")
 
-    canvas_size = int(graph_data.get("canvas_size", 840))
-    margin = int(graph_data.get("margin", 90))
+    canvas_size = graph_config.canvas_size
+    margin = graph_config.margin
 
     service, ctx, conn = prepare_run_session(loaded.setting_data, f"uv run main ({FEATURE_NAME})")
     try:
@@ -31,7 +33,7 @@ def run(config_loader: MainConfigLoader) -> int:
             service,
             ctx.run_id,
             matrix_data=loaded.matrix_data,
-            graph_data=loaded.graph_data,
+            graph_data={"canvas_size": canvas_size, "margin": margin},
             setting_data=loaded.setting_data,
         )
         out_file = service.artifact_store.run_dir(ctx.run_id) / "output" / "character_vector.svg"

--- a/src/monocycle_nash/loader/main_config.py
+++ b/src/monocycle_nash/loader/main_config.py
@@ -1,23 +1,20 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 
+from monocycle_nash.application_ports import (
+    ApproximationConfig,
+    CharacterGraphConfig,
+    LoadedFeatureInputs,
+    PayoffGraphConfig,
+    RandomMatrixConfig,
+)
 from monocycle_nash.loader.data_loader import ExperimentDataLoader, SettingDataLoader
-from monocycle_nash.loader.runtime_common import validate_graph_input, validate_matrix_input, validate_setting_input
+from monocycle_nash.loader.runtime_common import validate_matrix_input, validate_setting_input
 from monocycle_nash.loader.toml_tree import TomlTreeLoader
 
 
 DEFAULT_MAIN_CONFIG_PATH = Path("data/run_config/main.toml")
-
-
-@dataclass(frozen=True)
-class LoadedFeatureInputs:
-    matrix_data: dict
-    graph_data: dict | None
-    approximation_data: dict | None
-    random_matrix_data: dict | None
-    setting_data: dict
 
 
 class MainConfigLoader:
@@ -32,7 +29,7 @@ class MainConfigLoader:
             raise ValueError("main_config.features は空でない文字列配列で指定してください")
         return features
 
-    def load_inputs_for_feature(self, feature: str, *, graph_section: str | None = None) -> LoadedFeatureInputs:
+    def load_inputs_for_feature(self, feature: str) -> LoadedFeatureInputs:
         cfg = self._load_main_config()
         merged = self._resolve_feature_config(cfg, feature)
 
@@ -44,22 +41,75 @@ class MainConfigLoader:
 
         exp_loader = ExperimentDataLoader(base_dir=self._main_config_path.parent.parent)
         matrix_data = exp_loader.load("matrix", matrix_name)
-        loaded_graph = exp_loader.load("graph", graph_name) if graph_name is not None else None
         approximation_data = exp_loader.load("approximation", approximation_name) if approximation_name is not None else None
         random_matrix_data = exp_loader.load("random_matrix", random_matrix_name) if random_matrix_name is not None else None
-        graph_data = loaded_graph if graph_section is None else self._select_graph_section(loaded_graph, graph_section=graph_section)
+        graph_data = exp_loader.load("graph", graph_name) if graph_name is not None else None
 
         setting = SettingDataLoader(base_dir=self._main_config_path.parent.parent / "setting").load(setting_name)
 
         validate_matrix_input(matrix_data)
-        validate_graph_input(graph_data)
         validate_setting_input(setting)
+
         return LoadedFeatureInputs(
             matrix_data=matrix_data,
-            graph_data=graph_data,
-            approximation_data=approximation_data,
-            random_matrix_data=random_matrix_data,
+            graph_config=self._build_graph_config(feature, graph_data),
+            approximation_config=self._build_approximation_config(feature, approximation_data),
+            random_matrix_config=self._build_random_matrix_config(feature, random_matrix_data),
             setting_data=setting,
+        )
+
+    def load_matrix_data(self, matrix_name: str) -> dict:
+        if not isinstance(matrix_name, str) or not matrix_name:
+            raise ValueError("matrix_name は空でない文字列で指定してください")
+        exp_loader = ExperimentDataLoader(base_dir=self._main_config_path.parent.parent)
+        matrix_data = exp_loader.load("matrix", matrix_name)
+        validate_matrix_input(matrix_data)
+        return matrix_data
+
+    def _build_graph_config(self, feature: str, graph_data: dict | None) -> PayoffGraphConfig | CharacterGraphConfig | None:
+        if feature == "graph_payoff":
+            section = self._require_graph_section(graph_data, "payoff")
+            return PayoffGraphConfig(
+                threshold=float(section.get("threshold", 0.0)),
+                canvas_size=int(section.get("canvas_size", 840)),
+            )
+        if feature == "plot_characters":
+            section = self._require_graph_section(graph_data, "character")
+            return CharacterGraphConfig(
+                canvas_size=int(section.get("canvas_size", 840)),
+                margin=int(section.get("margin", 90)),
+            )
+        return None
+
+    def _build_approximation_config(self, feature: str, data: dict | None) -> ApproximationConfig | None:
+        if feature not in {"compare_approximation", "compare_random_approximation"}:
+            return None
+        if data is None:
+            raise ValueError(f"{feature}.approximation は必須です")
+
+        return ApproximationConfig(
+            source_matrix_name=self._optional_non_empty_str(data, key="source_matrix", name="approximation.source_matrix"),
+            reference_matrix_name=self._optional_non_empty_str(data, key="reference_matrix", name="approximation.reference_matrix"),
+            approximation_name=self._resolve_algorithm_name(data, kind="approximation", default="MonocycleToGeneralApproximation"),
+            distance_name=self._resolve_algorithm_name(data, kind="distance", default="MaxElementDifferenceDistance"),
+            raw_input=data,
+        )
+
+    def _build_random_matrix_config(self, feature: str, data: dict | None) -> RandomMatrixConfig | None:
+        if feature != "compare_random_approximation":
+            return None
+        if data is None:
+            raise ValueError("compare_random_approximation.random_matrix は必須です")
+
+        return RandomMatrixConfig(
+            size=self._required_int(data, key="size", default=None),
+            generation_count=self._required_int(data, key="generation_count", default=100),
+            acceptance_condition=self._optional_str(data, key="acceptance_condition", default=""),
+            low=self._required_float(data, key="low", default=-1.0),
+            high=self._required_float(data, key="high", default=1.0),
+            max_attempts=self._required_int(data, key="max_attempts", default=10_000),
+            random_seed=self._optional_int(data, key="random_seed"),
+            raw_input=data,
         )
 
     def _load_main_config(self) -> dict:
@@ -92,6 +142,13 @@ class MainConfigLoader:
             raise ValueError(f"{name} は空でない文字列で指定してください")
         return value
 
+    @staticmethod
+    def _optional_str(container: dict, *, key: str, default: str) -> str:
+        value = container.get(key, default)
+        if not isinstance(value, str):
+            raise ValueError(f"{key} は文字列で指定してください")
+        return value
+
     @classmethod
     def _require_non_empty_str(cls, container: dict, *, key: str, name: str) -> str:
         value = cls._optional_non_empty_str(container, key=key, name=name)
@@ -106,7 +163,6 @@ class MainConfigLoader:
             raise ValueError(f"{feature}.approximation は必須です")
         return value
 
-
     @classmethod
     def _resolve_random_matrix_name(cls, container: dict, *, feature: str) -> str | None:
         value = cls._optional_non_empty_str(container, key="random_matrix", name=f"{feature}.random_matrix")
@@ -115,7 +171,7 @@ class MainConfigLoader:
         return value
 
     @staticmethod
-    def _select_graph_section(graph_data: dict | None, *, graph_section: str) -> dict:
+    def _require_graph_section(graph_data: dict | None, graph_section: str) -> dict:
         if graph_data is None:
             raise ValueError(f"{graph_section} 用の graph 設定が必要です")
         section_data = graph_data.get(graph_section)
@@ -124,3 +180,41 @@ class MainConfigLoader:
         if not isinstance(section_data, dict):
             raise ValueError(f"graph.{graph_section} はテーブルで指定してください")
         return section_data
+
+    @staticmethod
+    def _resolve_algorithm_name(data: dict, *, kind: str, default: str) -> str:
+        candidates = [
+            data,
+            data.get("approximation") if isinstance(data.get("approximation"), dict) else None,
+            data.get("approxmation") if isinstance(data.get("approxmation"), dict) else None,
+        ]
+        for container in candidates:
+            if container is None:
+                continue
+            value = container.get(kind)
+            if isinstance(value, str) and value:
+                return value
+        return default
+
+    @staticmethod
+    def _required_int(config: dict, *, key: str, default: int | None) -> int:
+        raw = config.get(key, default)
+        if not isinstance(raw, int):
+            raise ValueError(f"random_matrix.{key} は整数で指定してください")
+        return raw
+
+    @staticmethod
+    def _optional_int(config: dict, *, key: str) -> int | None:
+        raw = config.get(key)
+        if raw is None:
+            return None
+        if not isinstance(raw, int):
+            raise ValueError(f"random_matrix.{key} は整数で指定してください")
+        return raw
+
+    @staticmethod
+    def _required_float(config: dict, *, key: str, default: float) -> float:
+        raw = config.get(key, default)
+        if not isinstance(raw, (int, float)):
+            raise ValueError(f"random_matrix.{key} は数値で指定してください")
+        return float(raw)

--- a/tests/loader/test_main_config.py
+++ b/tests/loader/test_main_config.py
@@ -32,12 +32,12 @@ def test_main_config_loader_resolves_shared_and_feature_override(tmp_path: Path)
     _write(data_dir / "setting" / "local.toml", '[output]\nbase_dir = "result"')
 
     loader = MainConfigLoader(data_dir / "run_config" / "main.toml")
-    loaded = loader.load_inputs_for_feature("graph_payoff", graph_section="payoff")
+    loaded = loader.load_inputs_for_feature("graph_payoff")
 
     assert loader.load_features() == ["graph_payoff"]
     assert loaded.matrix_data["matrix"] == [[0, 1], [-1, 0]]
-    assert loaded.graph_data is not None
-    assert loaded.graph_data["canvas_size"] == 840
+    assert loaded.graph_config is not None
+    assert loaded.graph_config.canvas_size == 840
 
 
 def test_main_config_loader_requires_declared_feature_section(tmp_path: Path) -> None:
@@ -71,8 +71,8 @@ def test_main_config_loader_loads_approximation_for_compare_feature(tmp_path: Pa
     loader = MainConfigLoader(data_dir / "run_config" / "main.toml")
     loaded = loader.load_inputs_for_feature("compare_approximation")
 
-    assert loaded.approximation_data is not None
-    assert loaded.approximation_data["alpha"] == 0.5
+    assert loaded.approximation_config is not None
+    assert loaded.approximation_config.approximation_name == "MonocycleToGeneralApproximation"
 
 
 def test_main_config_loader_requires_approximation_for_compare_feature(tmp_path: Path) -> None:
@@ -121,8 +121,8 @@ def test_main_config_loader_loads_random_matrix_for_random_compare_feature(tmp_p
     loader = MainConfigLoader(data_dir / "run_config" / "main.toml")
     loaded = loader.load_inputs_for_feature("compare_random_approximation")
 
-    assert loaded.random_matrix_data is not None
-    assert loaded.random_matrix_data["size"] == 4
+    assert loaded.random_matrix_config is not None
+    assert loaded.random_matrix_config.size == 4
 
 
 def test_main_config_loader_requires_random_matrix_for_random_compare_feature(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Decouple feature apps from the concrete `MainConfigLoader` and centralize feature input shape by introducing explicit application ports and typed config objects to simplify downstream code and validations.
- Normalize how approximation/random-matrix/graph settings are represented and consumed so feature apps only rely on well-typed inputs instead of raw toml dicts.

### Description
- Add `src/monocycle_nash/application_ports.py` with `FeatureWorkflowInputPort` protocol and frozen dataclasses `LoadedFeatureInputs`, `ApproximationConfig`, `RandomMatrixConfig`, `PayoffGraphConfig`, and `CharacterGraphConfig` to represent feature inputs.
- Update feature entrypoints (`compare_approximation`, `compare_random_approximation`, `compare_payoff`, `solve_payoff`, `graph_payoff`, `plot_characters`) to accept `FeatureWorkflowInputPort` and to use the new typed config fields instead of raw dicts, and to write `raw_input` slices when snapshotting.
- Simplify approximation/distance builders in `compare_approximation_app.py` to accept algorithm names and remove legacy resolution helpers; adjust `compare_random_approximation_app.py` to parse `RandomMatrixConfig` instead of raw dicts and to build acceptance conditions from the typed field.
- Revamp `MainConfigLoader` to construct `LoadedFeatureInputs` with typed graph/approximation/random-matrix configs, add `load_matrix_data` helper, and centralize validation and parsing helpers (`_build_graph_config`, `_build_approximation_config`, `_build_random_matrix_config`, etc.).
- Update tests in `tests/loader/test_main_config.py` to assert against the new typed config fields.

### Testing
- Ran loader unit tests `pytest tests/loader/test_main_config.py` and assertions targeting the new `MainConfigLoader` behavior passed.
- Ran the project test subset with `pytest -q` covering modified modules and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c49127e0bc83309d838dafa151e3a9)