### PR TITLE
Use PayoffMatrix objects across infra and entrypoints; add TOML payload helper

### DIFF
--- a/src/monocycle_nash/application_ports.py
+++ b/src/monocycle_nash/application_ports.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Protocol
 
+from monocycle_nash.matrix.base import PayoffMatrix
+
 
 @dataclass(frozen=True)
 class ApproximationConfig:
@@ -39,7 +41,7 @@ class CharacterGraphConfig:
 
 @dataclass(frozen=True)
 class LoadedFeatureInputs:
-    matrix_data: dict
+    matrix: PayoffMatrix
     graph_config: PayoffGraphConfig | CharacterGraphConfig | None
     approximation_config: ApproximationConfig | None
     random_matrix_config: RandomMatrixConfig | None
@@ -51,4 +53,4 @@ class FeatureWorkflowInputPort(Protocol):
 
     def load_inputs_for_feature(self, feature: str) -> LoadedFeatureInputs: ...
 
-    def load_matrix_data(self, matrix_name: str) -> dict: ...
+    def load_matrix(self, matrix_name: str) -> PayoffMatrix: ...

--- a/src/monocycle_nash/approximation/compare_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_approximation_app.py
@@ -4,7 +4,7 @@ from monocycle_nash.loader.main_config import MainConfigLoader
 import traceback
 
 from monocycle_nash.approximation.infra import ApproximationFeatureInfrastructure
-from monocycle_nash.loader.runtime_common import _to_toml, build_matrix, prepare_run_session, write_input_snapshots, write_json
+from monocycle_nash.loader.runtime_common import _to_toml, matrix_to_toml_payload, prepare_run_session, write_input_snapshots, write_json
 from monocycle_nash.matrix import (
     ApproximationQualityEvaluator,
     DominantEigenpairMonocycleApproximation,
@@ -26,26 +26,27 @@ def run(config_loader: MainConfigLoader) -> int:
 
     service, ctx, conn = prepare_run_session(feature_config.setting_data, f"uv run main ({FEATURE_NAME})")
     try:
-        source_matrix_data = feature_config.source_matrix_data
-        reference_matrix_data = feature_config.reference_matrix_data
+        source_matrix = feature_config.source_matrix
+        reference_matrix = feature_config.reference_matrix
 
         write_input_snapshots(
             service,
             ctx.run_id,
-            matrix_data=source_matrix_data,
+            matrix_data=matrix_to_toml_payload(source_matrix),
             graph_data=None,
             setting_data=feature_config.setting_data,
         )
         input_dir = service.artifact_store.run_dir(ctx.run_id) / "input"
-        (input_dir / "reference_matrix.toml").write_text(_to_toml(reference_matrix_data), encoding="utf-8")
+        (input_dir / "reference_matrix.toml").write_text(
+            _to_toml(matrix_to_toml_payload(reference_matrix)),
+            encoding="utf-8",
+        )
         (input_dir / "approximation.toml").write_text(_to_toml(approximation_config.raw_input), encoding="utf-8")
 
         approximation = _build_approximation(approximation_config.approximation_name)
         distance = _build_distance(approximation_config.distance_name)
         evaluator = ApproximationQualityEvaluator(approximation, distance)
 
-        source_matrix = build_matrix(source_matrix_data)
-        reference_matrix = build_matrix(reference_matrix_data)
         score = evaluator.evaluate(source_matrix, reference_matrix)
 
         write_json(
@@ -86,5 +87,4 @@ def _build_distance(distance_name: str) -> PayoffMatrixDistance:
     if distance_name == "EquilibriumUStrategyDifferenceDistance":
         return EquilibriumUStrategyDifferenceDistance()
     raise ValueError(f"未対応の distance です: {distance_name}")
-
 

--- a/src/monocycle_nash/approximation/compare_random_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_random_approximation_app.py
@@ -12,12 +12,17 @@ from monocycle_nash.approximation.infra import ApproximationFeatureInfrastructur
 from monocycle_nash.approximation.random_experiment_domain import ApproximationQualityStatistics, ApproximationQualitySummary
 from monocycle_nash.loader.runtime_common import (
     _to_toml,
-    build_matrix,
+    matrix_to_toml_payload,
     prepare_run_session,
     write_input_snapshots,
     write_json,
 )
-from monocycle_nash.matrix import ApproximationQualityEvaluator, RandomMatrixAcceptanceCondition, generate_random_skew_symmetric_matrix
+from monocycle_nash.matrix import (
+    ApproximationQualityEvaluator,
+    PayoffMatrixBuilder,
+    RandomMatrixAcceptanceCondition,
+    generate_random_skew_symmetric_matrix,
+)
 
 
 FEATURE_NAME = "compare_random_approximation"
@@ -54,7 +59,7 @@ def run(config_loader: MainConfigLoader) -> int:
         write_input_snapshots(
             service,
             ctx.run_id,
-            matrix_data=feature_config.matrix_data,
+            matrix_data=matrix_to_toml_payload(feature_config.matrix),
             graph_data=None,
             setting_data=feature_config.setting_data,
         )
@@ -79,7 +84,7 @@ def run(config_loader: MainConfigLoader) -> int:
                 rng=rng,
                 max_attempts=generation_cfg.max_attempts,
             )
-            source = build_matrix({"matrix": raw_matrix.tolist()})
+            source = PayoffMatrixBuilder.from_general_matrix(raw_matrix)
             score = evaluator.evaluate(source, source)
             parameters = approximation.quality_parameters(source, config=approximation_config.raw_input)
             statistics.add(score, parameters=parameters)
@@ -171,5 +176,4 @@ def _build_acceptance_condition(keyword: str) -> RandomMatrixAcceptanceCondition
     if keyword == "rank_at_least_4":
         return RankAtLeastFourCondition()
     raise ValueError(f"未対応の random_matrix.acceptance_condition です: {keyword}")
-
 

--- a/src/monocycle_nash/approximation/infra.py
+++ b/src/monocycle_nash/approximation/infra.py
@@ -6,6 +6,7 @@ from monocycle_nash.loader.data_loader import ExperimentDataLoader, SettingDataL
 from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import validate_setting_input
 from monocycle_nash.matrix import MatrixFileInfrastructure
+from monocycle_nash.matrix.base import PayoffMatrix
 
 
 @dataclass(frozen=True)
@@ -31,16 +32,16 @@ class RandomMatrixSettings:
 
 @dataclass(frozen=True)
 class CompareApproximationFeatureConfig:
-    matrix_data: dict
+    matrix: PayoffMatrix
     setting_data: dict
     approximation: ApproximationSettings
-    source_matrix_data: dict
-    reference_matrix_data: dict
+    source_matrix: PayoffMatrix
+    reference_matrix: PayoffMatrix
 
 
 @dataclass(frozen=True)
 class CompareRandomApproximationFeatureConfig:
-    matrix_data: dict
+    matrix: PayoffMatrix
     setting_data: dict
     approximation: ApproximationSettings
     random_matrix: RandomMatrixSettings
@@ -58,30 +59,30 @@ class ApproximationFeatureInfrastructure:
         approximation_name = _require_non_empty_str(merged, key="approximation", name="compare_approximation.approximation")
 
         matrix_repo = MatrixFileInfrastructure(base_dir=self._data_root)
-        matrix_data = matrix_repo.load_matrix_data(matrix_name)
+        matrix = matrix_repo.load_matrix(matrix_name)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
 
         approximation_data = ExperimentDataLoader(base_dir=self._data_root).load("approximation", approximation_name)
         approximation = _build_approximation_settings(approximation_data)
 
-        source_matrix_data = (
-            matrix_repo.load_matrix_data(approximation.source_matrix_name)
+        source_matrix = (
+            matrix_repo.load_matrix(approximation.source_matrix_name)
             if approximation.source_matrix_name is not None
-            else matrix_data
+            else matrix
         )
-        reference_matrix_data = (
-            matrix_repo.load_matrix_data(approximation.reference_matrix_name)
+        reference_matrix = (
+            matrix_repo.load_matrix(approximation.reference_matrix_name)
             if approximation.reference_matrix_name is not None
-            else matrix_data
+            else matrix
         )
 
         return CompareApproximationFeatureConfig(
-            matrix_data=matrix_data,
+            matrix=matrix,
             setting_data=setting,
             approximation=approximation,
-            source_matrix_data=source_matrix_data,
-            reference_matrix_data=reference_matrix_data,
+            source_matrix=source_matrix,
+            reference_matrix=reference_matrix,
         )
 
     def load_compare_random_approximation(self) -> CompareRandomApproximationFeatureConfig:
@@ -99,7 +100,7 @@ class ApproximationFeatureInfrastructure:
             name="compare_random_approximation.random_matrix",
         )
 
-        matrix_data = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_data(matrix_name)
+        matrix = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix(matrix_name)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
 
@@ -108,7 +109,7 @@ class ApproximationFeatureInfrastructure:
         random_matrix_data = exp_loader.load("random_matrix", random_matrix_name)
 
         return CompareRandomApproximationFeatureConfig(
-            matrix_data=matrix_data,
+            matrix=matrix,
             setting_data=setting,
             approximation=_build_approximation_settings(approximation_data),
             random_matrix=_build_random_matrix_settings(random_matrix_data),

--- a/src/monocycle_nash/equilibrium/infra.py
+++ b/src/monocycle_nash/equilibrium/infra.py
@@ -6,11 +6,12 @@ from monocycle_nash.loader.data_loader import SettingDataLoader
 from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import validate_setting_input
 from monocycle_nash.matrix import MatrixFileInfrastructure
+from monocycle_nash.matrix.base import PayoffMatrix
 
 
 @dataclass(frozen=True)
 class SolvePayoffFeatureConfig:
-    matrix_data: dict
+    matrix: PayoffMatrix
     setting_data: dict
 
 
@@ -24,20 +25,20 @@ class EquilibriumFeatureInfrastructure:
         matrix_name = _require_non_empty_str(merged, key="matrix", name="compare_payoff.matrix")
         setting_name = _require_non_empty_str(merged, key="setting", name="compare_payoff.setting")
 
-        matrix_data = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_data(matrix_name)
+        matrix = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix(matrix_name)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
-        return SolvePayoffFeatureConfig(matrix_data=matrix_data, setting_data=setting)
+        return SolvePayoffFeatureConfig(matrix=matrix, setting_data=setting)
 
     def load_solve_payoff(self) -> SolvePayoffFeatureConfig:
         merged = self._config_loader.load_feature_config("solve_payoff")
         matrix_name = _require_non_empty_str(merged, key="matrix", name="solve_payoff.matrix")
         setting_name = _require_non_empty_str(merged, key="setting", name="solve_payoff.setting")
 
-        matrix_data = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_data(matrix_name)
+        matrix = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix(matrix_name)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
-        return SolvePayoffFeatureConfig(matrix_data=matrix_data, setting_data=setting)
+        return SolvePayoffFeatureConfig(matrix=matrix, setting_data=setting)
 
 
 def _require_non_empty_str(container: dict, *, key: str, name: str) -> str:

--- a/src/monocycle_nash/equilibrium/solve_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/solve_payoff_app.py
@@ -6,7 +6,7 @@ import traceback
 import numpy as np
 
 from monocycle_nash.equilibrium.infra import EquilibriumFeatureInfrastructure
-from monocycle_nash.loader.runtime_common import build_matrix, prepare_run_session, write_input_snapshots, write_json
+from monocycle_nash.loader.runtime_common import matrix_to_toml_payload, prepare_run_session, write_input_snapshots, write_json
 from monocycle_nash.solver.selector import SolverSelector
 
 
@@ -15,14 +15,14 @@ FEATURE_NAME = "solve_payoff"
 
 def run(config_loader: MainConfigLoader) -> int:
     feature_config = EquilibriumFeatureInfrastructure(config_loader).load_solve_payoff()
-    matrix = build_matrix(feature_config.matrix_data)
+    matrix = feature_config.matrix
 
     service, ctx, conn = prepare_run_session(feature_config.setting_data, f"uv run main ({FEATURE_NAME})")
     try:
         write_input_snapshots(
             service,
             ctx.run_id,
-            matrix_data=feature_config.matrix_data,
+            matrix_data=matrix_to_toml_payload(matrix),
             graph_data=None,
             setting_data=feature_config.setting_data,
         )

--- a/src/monocycle_nash/graph/graph_payoff_app.py
+++ b/src/monocycle_nash/graph/graph_payoff_app.py
@@ -4,7 +4,7 @@ from monocycle_nash.loader.main_config import MainConfigLoader
 import traceback
 
 from monocycle_nash.graph.infra import GraphFeatureInfrastructure
-from monocycle_nash.loader.runtime_common import build_matrix, prepare_run_session, write_input_snapshots
+from monocycle_nash.loader.runtime_common import matrix_to_toml_payload, prepare_run_session, write_input_snapshots
 from monocycle_nash.visualization import PayoffDirectedGraphPlotter
 
 
@@ -13,7 +13,7 @@ FEATURE_NAME = "graph_payoff"
 
 def run(config_loader: MainConfigLoader) -> int:
     feature_config = GraphFeatureInfrastructure(config_loader).load_graph_payoff()
-    matrix = build_matrix(feature_config.matrix_data)
+    matrix = feature_config.matrix
 
     threshold = feature_config.threshold
     canvas_size = feature_config.canvas_size
@@ -23,7 +23,7 @@ def run(config_loader: MainConfigLoader) -> int:
         write_input_snapshots(
             service,
             ctx.run_id,
-            matrix_data=feature_config.matrix_data,
+            matrix_data=matrix_to_toml_payload(matrix),
             graph_data={"threshold": threshold, "canvas_size": canvas_size},
             setting_data=feature_config.setting_data,
         )

--- a/src/monocycle_nash/graph/infra.py
+++ b/src/monocycle_nash/graph/infra.py
@@ -4,13 +4,16 @@ from dataclasses import dataclass
 
 from monocycle_nash.loader.data_loader import ExperimentDataLoader, SettingDataLoader
 from monocycle_nash.loader.main_config import MainConfigLoader
+from monocycle_nash.matrix.infra import build_characters
 from monocycle_nash.loader.runtime_common import validate_setting_input
 from monocycle_nash.matrix import MatrixFileInfrastructure
+from monocycle_nash.matrix.base import PayoffMatrix
+from monocycle_nash.character.domain import Character
 
 
 @dataclass(frozen=True)
 class GraphPayoffFeatureConfig:
-    matrix_data: dict
+    matrix: PayoffMatrix
     setting_data: dict
     threshold: float
     canvas_size: int
@@ -18,7 +21,7 @@ class GraphPayoffFeatureConfig:
 
 @dataclass(frozen=True)
 class PlotCharactersFeatureConfig:
-    matrix_data: dict
+    characters: list[Character]
     setting_data: dict
     canvas_size: int
     margin: int
@@ -35,14 +38,14 @@ class GraphFeatureInfrastructure:
         setting_name = _require_non_empty_str(merged, key="setting", name="graph_payoff.setting")
         graph_name = _require_non_empty_str(merged, key="graph", name="graph_payoff.graph")
 
-        matrix_data = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_data(matrix_name)
+        matrix = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix(matrix_name)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
 
         graph_data = ExperimentDataLoader(base_dir=self._data_root).load("graph", graph_name)
         section = _require_graph_section(graph_data, "payoff")
         return GraphPayoffFeatureConfig(
-            matrix_data=matrix_data,
+            matrix=matrix,
             setting_data=setting,
             threshold=float(section.get("threshold", 0.0)),
             canvas_size=int(section.get("canvas_size", 840)),
@@ -54,14 +57,15 @@ class GraphFeatureInfrastructure:
         setting_name = _require_non_empty_str(merged, key="setting", name="plot_characters.setting")
         graph_name = _require_non_empty_str(merged, key="graph", name="plot_characters.graph")
 
-        matrix_data = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_data(matrix_name)
+        matrix_input = MatrixFileInfrastructure(base_dir=self._data_root).load_matrix_input(matrix_name)
+        characters = build_characters(matrix_input)
         setting = SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
         validate_setting_input(setting)
 
         graph_data = ExperimentDataLoader(base_dir=self._data_root).load("graph", graph_name)
         section = _require_graph_section(graph_data, "character")
         return PlotCharactersFeatureConfig(
-            matrix_data=matrix_data,
+            characters=characters,
             setting_data=setting,
             canvas_size=int(section.get("canvas_size", 840)),
             margin=int(section.get("margin", 90)),

--- a/src/monocycle_nash/graph/plot_characters_app.py
+++ b/src/monocycle_nash/graph/plot_characters_app.py
@@ -4,12 +4,7 @@ from monocycle_nash.loader.main_config import MainConfigLoader
 import traceback
 
 from monocycle_nash.graph.infra import GraphFeatureInfrastructure
-from monocycle_nash.loader.runtime_common import (
-    build_characters,
-    has_matrix_input,
-    prepare_run_session,
-    write_input_snapshots,
-)
+from monocycle_nash.loader.runtime_common import prepare_run_session, write_input_snapshots
 from monocycle_nash.visualization import CharacterVectorGraphPlotter
 
 
@@ -18,9 +13,7 @@ FEATURE_NAME = "plot_characters"
 
 def run(config_loader: MainConfigLoader) -> int:
     feature_config = GraphFeatureInfrastructure(config_loader).load_plot_characters()
-    if has_matrix_input(feature_config.matrix_data):
-        raise ValueError("plot_characters は matrix ではなく characters 入力が必須です")
-    characters = build_characters(feature_config.matrix_data)
+    characters = feature_config.characters
 
     canvas_size = feature_config.canvas_size
     margin = feature_config.margin
@@ -30,7 +23,12 @@ def run(config_loader: MainConfigLoader) -> int:
         write_input_snapshots(
             service,
             ctx.run_id,
-            matrix_data=feature_config.matrix_data,
+            matrix_data={
+                "characters": [
+                    {"label": character.label, "p": character.p, "v": [character.v.x, character.v.y]}
+                    for character in characters
+                ]
+            },
             graph_data={"canvas_size": canvas_size, "margin": margin},
             setting_data=feature_config.setting_data,
         )

--- a/src/monocycle_nash/loader/runtime_common.py
+++ b/src/monocycle_nash/loader/runtime_common.py
@@ -11,12 +11,6 @@ from monocycle_nash.loader.data_loader import ExperimentDataLoader, SettingDataL
 from monocycle_nash.loader.toml_tree import TomlTreeLoader
 from monocycle_nash.matrix import MatrixFileInfrastructure
 from monocycle_nash.matrix.base import PayoffMatrix
-from monocycle_nash.matrix.infra import (
-    build_characters as _build_characters,
-    build_matrix_from_input,
-    has_matrix_input as _has_matrix_input,
-    validate_matrix_input as _validate_matrix_input,
-)
 from monocycle_nash.runmeta.artifact_store import RunArtifactStore
 from monocycle_nash.runmeta.clock import now_jst_iso
 from monocycle_nash.runmeta.db import SQLiteConnectionFactory, migrate
@@ -73,22 +67,21 @@ def load_inputs(
     *,
     require_graph: bool,
     graph_section: str | None = None,
-) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any], Path]:
+) -> tuple[PayoffMatrix, dict[str, Any] | None, dict[str, Any], Path]:
     data_root = Path(data_dir)
     cfg = _load_run_config(run_config, data_root)
     refs = _resolve_run_config_refs(cfg, require_graph=require_graph)
 
     matrix_loader = MatrixFileInfrastructure(base_dir=data_root)
-    matrix_data = matrix_loader.load_matrix_data(refs.matrix)
+    matrix = matrix_loader.load_matrix(refs.matrix)
 
     exp_loader = ExperimentDataLoader(base_dir=data_root)
     loaded_graph_data = exp_loader.load("graph", refs.graph) if refs.graph is not None else None
     graph_data = _select_graph_section(loaded_graph_data, graph_section=graph_section)
     setting = SettingDataLoader(base_dir=data_root / "setting").load(refs.setting)
-    validate_matrix_input(matrix_data)
     validate_graph_input(graph_data)
     validate_setting_input(setting)
-    return matrix_data, graph_data, setting, _run_config_path(run_config, data_root)
+    return matrix, graph_data, setting, _run_config_path(run_config, data_root)
 
 
 class _RunConfigRefs:
@@ -125,20 +118,8 @@ def _optional_run_config_str(cfg: dict[str, Any], *, key: str) -> str | None:
     return value
 
 
-def build_matrix(matrix_data: dict[str, Any]) -> PayoffMatrix:
-    return build_matrix_from_input(matrix_data)
-
-
-def has_matrix_input(matrix_data: dict[str, Any]) -> bool:
-    return _has_matrix_input(matrix_data)
-
-
-def build_characters(matrix_data: dict[str, Any]):
-    return _build_characters(matrix_data)
-
-
-def validate_matrix_input(matrix_data: dict[str, Any]) -> None:
-    _validate_matrix_input(matrix_data)
+def matrix_to_toml_payload(matrix: PayoffMatrix) -> dict[str, Any]:
+    return {"matrix": matrix.matrix.tolist(), "labels": matrix.labels}
 
 
 def validate_graph_input(graph_data: dict[str, Any] | None) -> None:

--- a/src/monocycle_nash/matrix/infra.py
+++ b/src/monocycle_nash/matrix/infra.py
@@ -28,14 +28,14 @@ class MatrixFileInfrastructure:
         self._entry_file = entry_file
         self._tree_loader = tree_loader or TomlTreeLoader()
 
-    def load_matrix_data(self, matrix_name: str) -> dict[str, Any]:
+    def load_matrix_input(self, matrix_name: str) -> dict[str, Any]:
         matrix_path = self._base_dir / "matrix" / matrix_name / self._entry_file
         matrix_data = self._tree_loader.load(matrix_path)
         validate_matrix_input(matrix_data)
         return matrix_data
 
     def load_matrix(self, matrix_name: str) -> PayoffMatrix:
-        matrix_data = self.load_matrix_data(matrix_name)
+        matrix_data = self.load_matrix_input(matrix_name)
         return build_matrix_from_input(matrix_data)
 
 

--- a/tests/entrypoints/test_common.py
+++ b/tests/entrypoints/test_common.py
@@ -6,22 +6,18 @@ import pytest
 import monocycle_nash.runmeta.project_refs as project_refs_mod
 from monocycle_nash.runmeta.repositories import UNASSIGNED_PROJECT_ID
 
-from monocycle_nash.loader.runtime_common import (
-    build_characters,
-    build_matrix,
-    prepare_run_session,
-    write_input_snapshots,
-)
+from monocycle_nash.loader.runtime_common import prepare_run_session, write_input_snapshots
+from monocycle_nash.matrix.infra import build_characters, build_matrix_from_input
 
 
 def test_build_matrix_requires_exclusive_matrix_or_characters() -> None:
     with pytest.raises(ValueError, match="どちらか片方"):
-        build_matrix({"matrix": [[0.0]], "characters": [{"label": "a", "p": 1.0, "v": [0.0, 1.0]}]})
+        build_matrix_from_input({"matrix": [[0.0]], "characters": [{"label": "a", "p": 1.0, "v": [0.0, 1.0]}]})
 
 
 def test_build_matrix_from_characters_rejects_duplicate_labels() -> None:
     with pytest.raises(ValueError, match="重複"):
-        build_matrix(
+        build_matrix_from_input(
             {
                 "characters": [
                     {"label": "a", "p": 1.0, "v": [0.0, 1.0]},
@@ -253,7 +249,7 @@ def test_prepare_run_session_writes_txt_when_symlink_and_junction_fail(tmp_path:
 
 
 def test_build_matrix_team_mode_with_empty_string_uses_input_matrix_as_is() -> None:
-    matrix = build_matrix(
+    matrix = build_matrix_from_input(
         {
             "matrix": [[0.0, 1.0], [-1.0, 0.0]],
             "team": "",
@@ -266,7 +262,7 @@ def test_build_matrix_team_mode_with_empty_string_uses_input_matrix_as_is() -> N
 
 
 def test_build_matrix_team_mode_generates_default_team_payoff_matrix() -> None:
-    matrix = build_matrix(
+    matrix = build_matrix_from_input(
         {
             "matrix": [
                 [0.0, 2.0, -1.0],
@@ -283,7 +279,7 @@ def test_build_matrix_team_mode_generates_default_team_payoff_matrix() -> None:
 
 
 def test_build_matrix_team_mode_accepts_explicit_teams() -> None:
-    matrix = build_matrix(
+    matrix = build_matrix_from_input(
         {
             "matrix": [
                 [0.0, 1.0, -1.0],
@@ -305,12 +301,12 @@ def test_build_matrix_team_mode_accepts_explicit_teams() -> None:
 
 def test_build_matrix_rejects_unknown_team_mode() -> None:
     with pytest.raises(ValueError, match='team は "", "strict", "2by2", "monocycle"'):
-        build_matrix({"matrix": [[0.0, 1.0], [-1.0, 0.0]], "team": "fast"})
+        build_matrix_from_input({"matrix": [[0.0, 1.0], [-1.0, 0.0]], "team": "fast"})
 
 
 def test_build_matrix_rejects_teams_without_team_mode() -> None:
     with pytest.raises(ValueError, match="team モード"):
-        build_matrix(
+        build_matrix_from_input(
             {
                 "matrix": [[0.0, 1.0], [-1.0, 0.0]],
                 "teams": [{"label": "AB", "members": [0, 1]}],

--- a/tests/matrix/test_infra.py
+++ b/tests/matrix/test_infra.py
@@ -10,14 +10,14 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text.strip() + "\n", encoding="utf-8")
 
 
-def test_matrix_file_infrastructure_loads_matrix_data(tmp_path: Path) -> None:
+def test_matrix_file_infrastructure_loads_matrix(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     _write(data_dir / "matrix" / "rps3" / "data.toml", 'matrix = [[0, 1], [-1, 0]]')
 
     infra = MatrixFileInfrastructure(base_dir=data_dir)
-    matrix_data = infra.load_matrix_data("rps3")
+    matrix = infra.load_matrix("rps3")
 
-    assert matrix_data["matrix"] == [[0, 1], [-1, 0]]
+    assert matrix.matrix.tolist() == [[0.0, 1.0], [-1.0, 0.0]]
 
 
 def test_matrix_file_infrastructure_initializes_payoff_matrix(tmp_path: Path) -> None:


### PR DESCRIPTION
### Motivation
- Move from passing raw matrix dicts to strongly-typed `PayoffMatrix` objects across infra and entrypoints to centralize matrix construction and simplify downstream code.
- Ensure consistent serialization when writing input snapshots by providing a TOML-friendly payload helper.

### Description
- Replace raw matrix payloads (`matrix_data`) with `PayoffMatrix` instances returned by `MatrixFileInfrastructure.load_matrix` and propagated through feature config dataclasses and app entrypoints.
- Add `MatrixFileInfrastructure.load_matrix_input` (formerly `load_matrix_data`) for loading raw input and `load_matrix` to build a `PayoffMatrix`, and migrate callers accordingly in `approximation`, `equilibrium`, and `graph` infra and apps.
- Replace ad-hoc `build_matrix` usage with `build_matrix_from_input`/`PayoffMatrixBuilder` where appropriate and introduce `matrix_to_toml_payload` in `loader.runtime_common` to serialize `PayoffMatrix` into a TOML-friendly dict for `write_input_snapshots`.
- Update graph character plotting to construct `characters` via `build_characters` from matrix input and emit a normalized `matrix_data` snapshot containing character vectors.

### Testing
- Updated unit tests and ran `pytest` on modified modules including `tests/entrypoints/test_common.py` and `tests/matrix/test_infra.py` to reflect API changes, and the test suite succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4a8ad89f88330a1fc86285dfa0ebc)