### PR TITLE
Introduce setting-loader interfaces and move feature dataclasses to app modules to decouple infra

### DIFF
--- a/src/monocycle_nash/approximation/compare_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_approximation_app.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from monocycle_nash.loader.main_config import MainConfigLoader
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 import traceback
 
-from monocycle_nash.approximation.infra import ApproximationFeatureInfrastructure, ApproximationSettings
+from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import _to_toml, matrix_to_toml_payload, prepare_run_session, write_input_snapshots, write_json
 from monocycle_nash.matrix import (
     ApproximationQualityEvaluator,
@@ -15,13 +16,42 @@ from monocycle_nash.matrix import (
     PayoffMatrixApproximation,
     PayoffMatrixDistance,
 )
+from monocycle_nash.matrix.base import PayoffMatrix
+from monocycle_nash.runmeta.setting_domain import RuntimeSetting
+
+
+@dataclass(frozen=True)
+class ApproximationSettings:
+    source_matrix_name: str | None
+    reference_matrix_name: str | None
+    approximation_name: str
+    distance_name: str
+    dominant_eigen_ratio_bin_edges: tuple[float, ...] | None
+
+
+@dataclass(frozen=True)
+class CompareApproximationFeatureConfig:
+    matrix: PayoffMatrix
+    setting_data: RuntimeSetting
+    approximation: ApproximationSettings
+    source_matrix: PayoffMatrix
+    reference_matrix: PayoffMatrix
+
+
+class CompareApproximationSettingLoader(ABC):
+    @abstractmethod
+    def load_compare_approximation(self) -> CompareApproximationFeatureConfig:
+        raise NotImplementedError
 
 
 FEATURE_NAME = "compare_approximation"
 
 
 def run(config_loader: MainConfigLoader) -> int:
-    feature_config = ApproximationFeatureInfrastructure(config_loader).load_compare_approximation()
+    from monocycle_nash.approximation.infra import ApproximationFeatureInfrastructure
+
+    setting_loader: CompareApproximationSettingLoader = ApproximationFeatureInfrastructure(config_loader)
+    feature_config = setting_loader.load_compare_approximation()
     approximation_config = feature_config.approximation
 
     service, ctx, conn = prepare_run_session(feature_config.setting_data, f"uv run main ({FEATURE_NAME})")

--- a/src/monocycle_nash/approximation/compare_random_approximation_app.py
+++ b/src/monocycle_nash/approximation/compare_random_approximation_app.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
 from monocycle_nash.loader.main_config import MainConfigLoader
 import traceback
-from dataclasses import asdict, dataclass
 from typing import Any
 
 import numpy as np
 
-from monocycle_nash.approximation.compare_approximation_app import _build_approximation, _build_distance
-from monocycle_nash.approximation.infra import (
-    ApproximationFeatureInfrastructure,
+from monocycle_nash.approximation.compare_approximation_app import (
     ApproximationSettings,
-    RandomMatrixSettings,
+    _build_approximation,
+    _build_distance,
 )
 from monocycle_nash.approximation.random_experiment_domain import ApproximationQualityStatistics, ApproximationQualitySummary
 from monocycle_nash.loader.runtime_common import (
@@ -27,6 +27,8 @@ from monocycle_nash.matrix import (
     RandomMatrixAcceptanceCondition,
     generate_random_skew_symmetric_matrix,
 )
+from monocycle_nash.matrix.base import PayoffMatrix
+from monocycle_nash.runmeta.setting_domain import RuntimeSetting
 
 
 FEATURE_NAME = "compare_random_approximation"
@@ -43,6 +45,31 @@ class RandomGenerationConfig:
     random_seed: int | None
 
 
+@dataclass(frozen=True)
+class RandomMatrixSettings:
+    size: int
+    generation_count: int
+    acceptance_condition: str
+    low: float
+    high: float
+    max_attempts: int
+    random_seed: int | None
+
+
+@dataclass(frozen=True)
+class CompareRandomApproximationFeatureConfig:
+    matrix: PayoffMatrix
+    setting_data: RuntimeSetting
+    approximation: ApproximationSettings
+    random_matrix: RandomMatrixSettings
+
+
+class CompareRandomApproximationSettingLoader(ABC):
+    @abstractmethod
+    def load_compare_random_approximation(self) -> CompareRandomApproximationFeatureConfig:
+        raise NotImplementedError
+
+
 class EvenSizeCondition(RandomMatrixAcceptanceCondition):
     def is_satisfied(self, matrix: np.ndarray) -> bool:
         return matrix.shape[0] % 2 == 0
@@ -54,7 +81,10 @@ class RankAtLeastFourCondition(RandomMatrixAcceptanceCondition):
 
 
 def run(config_loader: MainConfigLoader) -> int:
-    feature_config = ApproximationFeatureInfrastructure(config_loader).load_compare_random_approximation()
+    from monocycle_nash.approximation.infra import ApproximationFeatureInfrastructure
+
+    setting_loader: CompareRandomApproximationSettingLoader = ApproximationFeatureInfrastructure(config_loader)
+    feature_config = setting_loader.load_compare_random_approximation()
     approximation_config = feature_config.approximation
     random_matrix_config = feature_config.random_matrix
 

--- a/src/monocycle_nash/approximation/infra.py
+++ b/src/monocycle_nash/approximation/infra.py
@@ -1,53 +1,22 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
+from monocycle_nash.approximation.compare_approximation_app import (
+    ApproximationSettings,
+    CompareApproximationFeatureConfig,
+    CompareApproximationSettingLoader,
+)
+from monocycle_nash.approximation.compare_random_approximation_app import (
+    CompareRandomApproximationFeatureConfig,
+    CompareRandomApproximationSettingLoader,
+    RandomMatrixSettings,
+)
 from monocycle_nash.loader.data_loader import ExperimentDataLoader, SettingDataLoader
 from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import TomlRuntimeSettingParser
 from monocycle_nash.matrix import MatrixFileInfrastructure
-from monocycle_nash.matrix.base import PayoffMatrix
-from monocycle_nash.runmeta.setting_domain import RuntimeSetting
 
 
-@dataclass(frozen=True)
-class ApproximationSettings:
-    source_matrix_name: str | None
-    reference_matrix_name: str | None
-    approximation_name: str
-    distance_name: str
-    dominant_eigen_ratio_bin_edges: tuple[float, ...] | None
-
-
-@dataclass(frozen=True)
-class RandomMatrixSettings:
-    size: int
-    generation_count: int
-    acceptance_condition: str
-    low: float
-    high: float
-    max_attempts: int
-    random_seed: int | None
-
-
-@dataclass(frozen=True)
-class CompareApproximationFeatureConfig:
-    matrix: PayoffMatrix
-    setting_data: RuntimeSetting
-    approximation: ApproximationSettings
-    source_matrix: PayoffMatrix
-    reference_matrix: PayoffMatrix
-
-
-@dataclass(frozen=True)
-class CompareRandomApproximationFeatureConfig:
-    matrix: PayoffMatrix
-    setting_data: RuntimeSetting
-    approximation: ApproximationSettings
-    random_matrix: RandomMatrixSettings
-
-
-class ApproximationFeatureInfrastructure:
+class ApproximationFeatureInfrastructure(CompareApproximationSettingLoader, CompareRandomApproximationSettingLoader):
     def __init__(self, config_loader: MainConfigLoader):
         self._config_loader = config_loader
         self._data_root = config_loader.data_root

--- a/src/monocycle_nash/equilibrium/compare_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/compare_payoff_app.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from monocycle_nash.equilibrium.infra import EquilibriumFeatureInfrastructure
+from monocycle_nash.equilibrium.solve_payoff_app import EquilibriumSettingLoader
 from monocycle_nash.loader.main_config import MainConfigLoader
 
 
@@ -8,5 +8,8 @@ FEATURE_NAME = "compare_payoff"
 
 
 def run(config_loader: MainConfigLoader) -> int:
-    EquilibriumFeatureInfrastructure(config_loader).load_compare_payoff()
+    from monocycle_nash.equilibrium.infra import EquilibriumFeatureInfrastructure
+
+    setting_loader: EquilibriumSettingLoader = EquilibriumFeatureInfrastructure(config_loader)
+    setting_loader.load_compare_payoff()
     return 0

--- a/src/monocycle_nash/equilibrium/infra.py
+++ b/src/monocycle_nash/equilibrium/infra.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-
+from monocycle_nash.equilibrium.solve_payoff_app import EquilibriumSettingLoader, SolvePayoffFeatureConfig
 from monocycle_nash.loader.data_loader import SettingDataLoader
 from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import TomlRuntimeSettingParser
 from monocycle_nash.matrix import MatrixFileInfrastructure
-from monocycle_nash.matrix.base import PayoffMatrix
-from monocycle_nash.runmeta.setting_domain import RuntimeSetting
 
 
-@dataclass(frozen=True)
-class SolvePayoffFeatureConfig:
-    matrix: PayoffMatrix
-    setting_data: RuntimeSetting
-
-
-class EquilibriumFeatureInfrastructure:
+class EquilibriumFeatureInfrastructure(EquilibriumSettingLoader):
     def __init__(self, config_loader: MainConfigLoader):
         self._config_loader = config_loader
         self._data_root = config_loader.data_root

--- a/src/monocycle_nash/equilibrium/solve_payoff_app.py
+++ b/src/monocycle_nash/equilibrium/solve_payoff_app.py
@@ -1,20 +1,42 @@
 from __future__ import annotations
 
-from monocycle_nash.loader.main_config import MainConfigLoader
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 import traceback
 
 import numpy as np
 
-from monocycle_nash.equilibrium.infra import EquilibriumFeatureInfrastructure
+from monocycle_nash.loader.main_config import MainConfigLoader
 from monocycle_nash.loader.runtime_common import matrix_to_toml_payload, prepare_run_session, write_input_snapshots, write_json
+from monocycle_nash.matrix.base import PayoffMatrix
+from monocycle_nash.runmeta.setting_domain import RuntimeSetting
 from monocycle_nash.solver.selector import SolverSelector
 
 
 FEATURE_NAME = "solve_payoff"
 
 
+@dataclass(frozen=True)
+class SolvePayoffFeatureConfig:
+    matrix: PayoffMatrix
+    setting_data: RuntimeSetting
+
+
+class EquilibriumSettingLoader(ABC):
+    @abstractmethod
+    def load_compare_payoff(self) -> SolvePayoffFeatureConfig:
+        raise NotImplementedError
+
+    @abstractmethod
+    def load_solve_payoff(self) -> SolvePayoffFeatureConfig:
+        raise NotImplementedError
+
+
 def run(config_loader: MainConfigLoader) -> int:
-    feature_config = EquilibriumFeatureInfrastructure(config_loader).load_solve_payoff()
+    from monocycle_nash.equilibrium.infra import EquilibriumFeatureInfrastructure
+
+    setting_loader: EquilibriumSettingLoader = EquilibriumFeatureInfrastructure(config_loader)
+    feature_config = setting_loader.load_solve_payoff()
     matrix = feature_config.matrix
 
     service, ctx, conn = prepare_run_session(feature_config.setting_data, f"uv run main ({FEATURE_NAME})")


### PR DESCRIPTION
### Motivation
- Prevent circular import issues between feature apps and infrastructure by decoupling configuration dataclasses from the infra module.
- Make feature infrastructure implement explicit loader interfaces so `run` functions can depend on abstract loaders instead of concrete infra classes.
- Centralize per-feature runtime datatypes next to feature entry points so setting parsing and typing are colocated with the feature logic.

### Description
- Moved `ApproximationSettings`, `RandomMatrixSettings`, `CompareApproximationFeatureConfig`, `CompareRandomApproximationFeatureConfig`, and `SolvePayoffFeatureConfig` dataclasses into their respective feature app modules and added typing for `PayoffMatrix` and `RuntimeSetting` where used.
- Added abstract loader interfaces `CompareApproximationSettingLoader`, `CompareRandomApproximationSettingLoader`, and `EquilibriumSettingLoader` to the app modules and updated `run` functions to import `ApproximationFeatureInfrastructure` / `EquilibriumFeatureInfrastructure` lazily and use the loader interfaces for typing.
- Updated `ApproximationFeatureInfrastructure` and `EquilibriumFeatureInfrastructure` to implement the new loader interfaces and removed duplicate dataclass definitions from `infra.py`.
- Adjusted imports and moved `_build_approximation` / `_build_distance` usage into the approximation apps to align with the new dataclass locations.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b5784d4c8330a202b93c968f89d4)