### PR TITLE
Add experiment_team_strict_spectrum runner and configuration

### DIFF
--- a/data/experiment/team_strict_spectrum/default/data.toml
+++ b/data/experiment/team_strict_spectrum/default/data.toml
@@ -1,0 +1,9 @@
+character_count = 6
+team_size = 2
+generation_count = 2000
+power_low = -1.0
+power_high = 1.0
+vector_low = -1.0
+vector_high = 1.0
+random_seed = 42
+support_threshold = 1e-6

--- a/data/run_config/main.toml
+++ b/data/run_config/main.toml
@@ -19,3 +19,6 @@ random_matrix = "default"
 [plot_characters]
 matrix = "janken_characters"
 graph = "default"
+
+[experiment_team_strict_spectrum]
+experiment = "default"

--- a/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
+++ b/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import asdict, dataclass
+import traceback
+from typing import Any
+
+import numpy as np
+
+from monocycle_nash.equilibrium.infra.solver.selector import SolverSelector
+from monocycle_nash.game.infra.matrix import build_matrix_from_input
+from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
+from monocycle_nash.runtime.infra.loader.runtime_common import (
+    _to_toml,
+    prepare_run_session,
+    write_input_snapshots,
+    write_json,
+)
+from monocycle_nash.runtime.infra.runmeta.setting_domain import RuntimeSetting
+
+
+FEATURE_NAME = "experiment_team_strict_spectrum"
+
+
+@dataclass(frozen=True)
+class TeamStrictExperimentSettings:
+    character_count: int
+    team_size: int
+    generation_count: int
+    random_seed: int | None
+    power_low: float
+    power_high: float
+    vector_low: float
+    vector_high: float
+    support_threshold: float = 1e-6
+    solver: str = ""
+
+
+@dataclass(frozen=True)
+class TeamStrictSpectrumFeatureConfig:
+    setting_data: RuntimeSetting
+    experiment: TeamStrictExperimentSettings
+
+
+class TeamStrictSpectrumSettingLoader(ABC):
+    @abstractmethod
+    def load_experiment_team_strict_spectrum(self) -> TeamStrictSpectrumFeatureConfig:
+        raise NotImplementedError
+
+
+def run(config_loader: MainConfigLoader) -> int:
+    from monocycle_nash.analysis.infra.approximation import ApproximationFeatureInfrastructure
+
+    setting_loader: TeamStrictSpectrumSettingLoader = ApproximationFeatureInfrastructure(config_loader)
+    feature_config = setting_loader.load_experiment_team_strict_spectrum()
+    settings = feature_config.experiment
+
+    service, ctx, conn = prepare_run_session(feature_config.setting_data, f"uv run main ({FEATURE_NAME})")
+    try:
+        snapshot_matrix_data = _build_matrix_input(np.random.default_rng(settings.random_seed), settings)
+        write_input_snapshots(
+            service,
+            ctx.run_id,
+            matrix_data=snapshot_matrix_data,
+            graph_data=None,
+            setting_data=feature_config.setting_data,
+        )
+        input_dir = service.artifact_store.run_dir(ctx.run_id) / "input"
+        (input_dir / "team_strict_spectrum.toml").write_text(
+            _to_toml(_experiment_to_toml_payload(settings)),
+            encoding="utf-8",
+        )
+
+        rng = np.random.default_rng(settings.random_seed)
+        trials = [_run_single_trial(rng, settings, trial_index=i) for i in range(settings.generation_count)]
+        summary = _summarize_trials(trials)
+
+        write_json(
+            service.artifact_store.run_dir(ctx.run_id) / "output" / "team_strict_spectrum_experiment.json",
+            {
+                "feature": FEATURE_NAME,
+                "settings": asdict(settings),
+                "trials": trials,
+                "summary": summary,
+            },
+        )
+
+        service.finish_success(ctx, extra_meta={"output_files": ["output/team_strict_spectrum_experiment.json"]})
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        err = traceback.format_exc()
+        (service.artifact_store.run_dir(ctx.run_id) / "logs" / "stderr.log").write_text(err, encoding="utf-8")
+        service.finish_fail(ctx, extra_meta={"error": str(exc)})
+        return 1
+    finally:
+        conn.close()
+
+
+def _run_single_trial(
+    rng: np.random.Generator,
+    settings: TeamStrictExperimentSettings,
+    *,
+    trial_index: int,
+) -> dict[str, Any]:
+    matrix_data = _build_matrix_input(rng, settings)
+    matrix = build_matrix_from_input(matrix_data)
+    eq = SolverSelector().solve(matrix)
+
+    imag_abs = matrix.eigenvalues()
+    imag_abs = imag_abs[imag_abs > 1e-10]
+    uniq = np.unique(np.round(imag_abs, decimals=10))
+    uniq_sorted = np.sort(uniq)[::-1]
+
+    lambda1 = _float_or_none(uniq_sorted, 0)
+    lambda2 = _float_or_none(uniq_sorted, 1)
+    lambda3 = _float_or_none(uniq_sorted, 2)
+
+    ratio2_to_1 = _ratio(lambda2, lambda1)
+    ratio3_to_1 = _ratio(lambda3, lambda1)
+    dominant_gap = _ratio(lambda1, lambda2)
+    support_size = int(np.sum(eq.probabilities > settings.support_threshold))
+
+    return {
+        "trial_index": trial_index,
+        "lambda1": lambda1,
+        "lambda2": lambda2,
+        "lambda3": lambda3,
+        "ratio2_to_1": ratio2_to_1,
+        "ratio3_to_1": ratio3_to_1,
+        "dominant_gap": dominant_gap,
+        "support_size": support_size,
+        "is_support_3": support_size == 3,
+    }
+
+
+def _build_matrix_input(rng: np.random.Generator, settings: TeamStrictExperimentSettings) -> dict[str, Any]:
+    if settings.character_count != 6:
+        raise ValueError("experiment_team_strict_spectrum.character_count は 6 固定です")
+    if settings.team_size != 2:
+        raise ValueError("experiment_team_strict_spectrum.team_size は 2 固定です")
+
+    characters: list[dict[str, Any]] = []
+    for i in range(settings.character_count):
+        characters.append(
+            {
+                "label": f"c{i}",
+                "p": float(rng.uniform(settings.power_low, settings.power_high)),
+                "v": [
+                    float(rng.uniform(settings.vector_low, settings.vector_high)),
+                    float(rng.uniform(settings.vector_low, settings.vector_high)),
+                ],
+            }
+        )
+    return {
+        "characters": characters,
+        "team": "strict",
+    }
+
+
+def _experiment_to_toml_payload(settings: TeamStrictExperimentSettings) -> dict[str, Any]:
+    payload = asdict(settings)
+    if payload["solver"] == "":
+        del payload["solver"]
+    return payload
+
+
+def _float_or_none(values: np.ndarray, index: int) -> float | None:
+    if values.size <= index:
+        return None
+    return float(values[index])
+
+
+def _ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None or denominator == 0.0:
+        return None
+    return float(numerator / denominator)
+
+
+def _summarize_trials(trials: list[dict[str, Any]]) -> dict[str, Any]:
+    ratio2_values = [float(v) for v in (t["ratio2_to_1"] for t in trials) if v is not None]
+    ratio3_values = [float(v) for v in (t["ratio3_to_1"] for t in trials) if v is not None]
+    support_sizes = [int(t["support_size"]) for t in trials]
+
+    histogram: dict[str, int] = {}
+    for size in support_sizes:
+        key = str(size)
+        histogram[key] = histogram.get(key, 0) + 1
+
+    gaps = np.asarray([float(v) for v in (t["dominant_gap"] for t in trials) if v is not None], dtype=float)
+    supports_for_gap = np.asarray(
+        [
+            int(t["support_size"])
+            for t in trials
+            if t["dominant_gap"] is not None
+        ],
+        dtype=float,
+    )
+    corr = None
+    if gaps.size >= 2 and supports_for_gap.size == gaps.size:
+        corr_matrix = np.corrcoef(gaps, supports_for_gap)
+        corr_value = float(corr_matrix[0, 1])
+        if np.isfinite(corr_value):
+            corr = corr_value
+
+    count = len(trials)
+    support_size_eq_3_rate = (
+        float(sum(1 for size in support_sizes if size == 3) / count)
+        if count > 0
+        else None
+    )
+
+    return {
+        "count": count,
+        "ratio2_to_1_mean": float(np.mean(ratio2_values)) if ratio2_values else None,
+        "ratio2_to_1_std": float(np.std(ratio2_values)) if ratio2_values else None,
+        "ratio3_to_1_mean": float(np.mean(ratio3_values)) if ratio3_values else None,
+        "ratio3_to_1_std": float(np.std(ratio3_values)) if ratio3_values else None,
+        "support_size_histogram": histogram,
+        "support_size_eq_3_rate": support_size_eq_3_rate,
+        "corr_dominant_gap_vs_support_size": corr,
+    }

--- a/src/monocycle_nash/analysis/infra/approximation.py
+++ b/src/monocycle_nash/analysis/infra/approximation.py
@@ -10,13 +10,22 @@ from monocycle_nash.analysis.app.compare_random_approximation import (
     CompareRandomApproximationSettingLoader,
     RandomMatrixSettings,
 )
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import (
+    TeamStrictExperimentSettings,
+    TeamStrictSpectrumFeatureConfig,
+    TeamStrictSpectrumSettingLoader,
+)
 from monocycle_nash.runtime.infra.loader.data_loader import ExperimentDataLoader, SettingDataLoader
 from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
 from monocycle_nash.runtime.infra.loader.runtime_common import TomlRuntimeSettingParser
 from monocycle_nash.game.infra.matrix import MatrixFileInfrastructure
 
 
-class ApproximationFeatureInfrastructure(CompareApproximationSettingLoader, CompareRandomApproximationSettingLoader):
+class ApproximationFeatureInfrastructure(
+    CompareApproximationSettingLoader,
+    CompareRandomApproximationSettingLoader,
+    TeamStrictSpectrumSettingLoader,
+):
     def __init__(self, config_loader: MainConfigLoader):
         self._config_loader = config_loader
         self._data_root = config_loader.data_root
@@ -86,6 +95,33 @@ class ApproximationFeatureInfrastructure(CompareApproximationSettingLoader, Comp
             random_matrix=_build_random_matrix_settings(random_matrix_data),
         )
 
+    def load_experiment_team_strict_spectrum(self) -> TeamStrictSpectrumFeatureConfig:
+        merged = self._config_loader.load_feature_config("experiment_team_strict_spectrum")
+        setting_name = _require_non_empty_str(
+            merged,
+            key="setting",
+            name="experiment_team_strict_spectrum.setting",
+        )
+        experiment_name = _require_non_empty_str(
+            merged,
+            key="experiment",
+            name="experiment_team_strict_spectrum.experiment",
+        )
+
+        setting = TomlRuntimeSettingParser().parse(
+            SettingDataLoader(base_dir=self._data_root / "setting").load(setting_name)
+        )
+        experiment_data = ExperimentDataLoader(base_dir=self._data_root).load(
+            "experiment/team_strict_spectrum",
+            experiment_name,
+        )
+
+        return TeamStrictSpectrumFeatureConfig(
+            setting_data=setting,
+            experiment=_build_team_strict_experiment_settings(experiment_data),
+        )
+
+
 
 def _build_approximation_settings(data: dict) -> ApproximationSettings:
     return ApproximationSettings(
@@ -107,6 +143,34 @@ def _build_random_matrix_settings(data: dict) -> RandomMatrixSettings:
         max_attempts=_required_int(data, key="max_attempts", default=10_000),
         random_seed=_optional_int(data, key="random_seed"),
     )
+
+
+def _build_team_strict_experiment_settings(data: dict) -> TeamStrictExperimentSettings:
+    settings = TeamStrictExperimentSettings(
+        character_count=_required_int(data, key="character_count", default=6),
+        team_size=_required_int(data, key="team_size", default=2),
+        generation_count=_required_int(data, key="generation_count", default=100),
+        random_seed=_optional_int(data, key="random_seed"),
+        power_low=_required_float(data, key="power_low", default=-1.0),
+        power_high=_required_float(data, key="power_high", default=1.0),
+        vector_low=_required_float(data, key="vector_low", default=-1.0),
+        vector_high=_required_float(data, key="vector_high", default=1.0),
+        support_threshold=_required_float(data, key="support_threshold", default=1e-6),
+        solver=_optional_str(data, key="solver", default=""),
+    )
+    if settings.character_count != 6:
+        raise ValueError("experiment_team_strict_spectrum.character_count は 6 で指定してください")
+    if settings.team_size != 2:
+        raise ValueError("experiment_team_strict_spectrum.team_size は 2 で指定してください")
+    if settings.generation_count <= 0:
+        raise ValueError("experiment_team_strict_spectrum.generation_count は 1 以上で指定してください")
+    if settings.power_low >= settings.power_high:
+        raise ValueError("experiment_team_strict_spectrum.power_low は power_high より小さくしてください")
+    if settings.vector_low >= settings.vector_high:
+        raise ValueError("experiment_team_strict_spectrum.vector_low は vector_high より小さくしてください")
+    if settings.support_threshold < 0:
+        raise ValueError("experiment_team_strict_spectrum.support_threshold は 0 以上で指定してください")
+    return settings
 
 
 def _optional_float_tuple(container: dict, *, key: str) -> tuple[float, ...] | None:

--- a/src/monocycle_nash/main.py
+++ b/src/monocycle_nash/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from monocycle_nash.analysis.app.compare_approximation import run as run_compare_approximation
 from monocycle_nash.analysis.app.compare_random_approximation import run as run_compare_random_approximation
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import run as run_experiment_team_strict_spectrum
 from monocycle_nash.equilibrium.app.compare_payoff import run as run_compare_payoff
 from monocycle_nash.equilibrium.app.solve_payoff import run as run_solve_payoff
 from monocycle_nash.analysis.app.graph_payoff import run as run_graph_payoff
@@ -21,6 +22,7 @@ def main() -> int:
         "compare_payoff": run_compare_payoff,
         "compare_approximation": run_compare_approximation,
         "compare_random_approximation": run_compare_random_approximation,
+        "experiment_team_strict_spectrum": run_experiment_team_strict_spectrum,
         "graph_payoff": run_graph_payoff,
         "plot_characters": run_plot_characters,
     }


### PR DESCRIPTION
### Motivation
- Provide an analysis feature to run repeated random experiments that generate 6 characters, build strict pair-team payoff matrices, compute eigenvalue-spectrum based ratios and equilibrium support properties, and aggregate results for hypothesis analysis.
- Integrate the experiment into the existing runmeta lifecycle so outputs and inputs are captured consistently with other analysis apps.

### Description
- Add a new runner file `src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py` implementing `run(config_loader: MainConfigLoader) -> int`, the `TeamStrictExperimentSettings` dataclass, a per-trial helper `_run_single_trial`, input snapshot writing, and JSON output to `output/team_strict_spectrum_experiment.json`.
- Implement per-trial logic to randomly generate 6 characters (`p ~ Uniform(power_low, power_high)` and `v` components ~ `Uniform(vector_low, vector_high)`), build a strict team payoff matrix via `build_matrix_from_input` (using `_build_default_pair_teams`), solve equilibrium with `SolverSelector().solve(matrix)`, compute alternating-matrix eigenvalue magnitudes via `matrix.eigenvalues()`, deduplicate/round/descend-sort unique values, compute `ratio2_to_1`, `ratio3_to_1`, `dominant_gap`, and `support_size` (using `support_threshold`).
- Add trial aggregation that saves per-trial fields (`trial_index`, `lambda1`, `lambda2`, `lambda3`, `ratio2_to_1`, `ratio3_to_1`, `support_size`, `dominant_gap`, `is_support_3`) and produces a `summary` including count, means/stds for ratios, `support_size_histogram`, `support_size_eq_3_rate`, and `corr_dominant_gap_vs_support_size`.
- Extend the approximation feature infrastructure `src/monocycle_nash/analysis/infra/approximation.py` with a loader for `experiment_team_strict_spectrum` and add a default experiment config `data/experiment/team_strict_spectrum/default/data.toml`, and register the new feature in `src/monocycle_nash/main.py` and `data/run_config/main.toml`.

### Testing
- Ran the full test suite with `uv run pytest` which completed successfully with `260 passed, 3 warnings`.
- No new unit tests were added for the feature in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7b135cc8833084fe4c4bb17b3b4e)