### PR TITLE
Add dominant-gap hypothesis metrics and per-trial CSV export

### DIFF
--- a/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
+++ b/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import csv
 from dataclasses import asdict, dataclass
 import traceback
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -73,19 +75,30 @@ def run(config_loader: MainConfigLoader) -> int:
 
         rng = np.random.default_rng(settings.random_seed)
         trials = [_run_single_trial(rng, settings, trial_index=i) for i in range(settings.generation_count)]
-        summary = _summarize_trials(trials)
+        summary, hypothesis_analysis = _summarize_trials(trials)
+        output_dir = service.artifact_store.run_dir(ctx.run_id) / "output"
+        _write_trials_csv(output_dir / "team_strict_spectrum_trials.csv", trials)
 
         write_json(
-            service.artifact_store.run_dir(ctx.run_id) / "output" / "team_strict_spectrum_experiment.json",
+            output_dir / "team_strict_spectrum_experiment.json",
             {
                 "feature": FEATURE_NAME,
                 "settings": asdict(settings),
                 "trials": trials,
                 "summary": summary,
+                "hypothesis_analysis": hypothesis_analysis,
             },
         )
 
-        service.finish_success(ctx, extra_meta={"output_files": ["output/team_strict_spectrum_experiment.json"]})
+        service.finish_success(
+            ctx,
+            extra_meta={
+                "output_files": [
+                    "output/team_strict_spectrum_experiment.json",
+                    "output/team_strict_spectrum_trials.csv",
+                ]
+            },
+        )
         return 0
     except Exception as exc:  # noqa: BLE001
         err = traceback.format_exc()
@@ -176,9 +189,10 @@ def _ratio(numerator: float | None, denominator: float | None) -> float | None:
     return float(numerator / denominator)
 
 
-def _summarize_trials(trials: list[dict[str, Any]]) -> dict[str, Any]:
+def _summarize_trials(trials: list[dict[str, Any]]) -> tuple[dict[str, Any], dict[str, Any]]:
     ratio2_values = [float(v) for v in (t["ratio2_to_1"] for t in trials) if v is not None]
     ratio3_values = [float(v) for v in (t["ratio3_to_1"] for t in trials) if v is not None]
+    dominant_gap_values = [float(v) for v in (t["dominant_gap"] for t in trials) if v is not None]
     support_sizes = [int(t["support_size"]) for t in trials]
 
     histogram: dict[str, int] = {}
@@ -209,13 +223,114 @@ def _summarize_trials(trials: list[dict[str, Any]]) -> dict[str, Any]:
         else None
     )
 
-    return {
+    summary = {
         "count": count,
         "ratio2_to_1_mean": float(np.mean(ratio2_values)) if ratio2_values else None,
         "ratio2_to_1_std": float(np.std(ratio2_values)) if ratio2_values else None,
         "ratio3_to_1_mean": float(np.mean(ratio3_values)) if ratio3_values else None,
         "ratio3_to_1_std": float(np.std(ratio3_values)) if ratio3_values else None,
+        "dominant_gap_mean": float(np.mean(dominant_gap_values)) if dominant_gap_values else None,
+        "dominant_gap_std": float(np.std(dominant_gap_values)) if dominant_gap_values else None,
         "support_size_histogram": histogram,
         "support_size_eq_3_rate": support_size_eq_3_rate,
         "corr_dominant_gap_vs_support_size": corr,
+        "support3_rate_gap_ge_2": _support3_rate_for_gap(trials, lower=2.0, upper=None),
+        "support3_rate_gap_lt_2": _support3_rate_for_gap(trials, lower=None, upper=2.0),
     }
+    ge_2 = summary["support3_rate_gap_ge_2"]
+    lt_2 = summary["support3_rate_gap_lt_2"]
+    summary["delta_support3_rate"] = ge_2 - lt_2 if ge_2 is not None and lt_2 is not None else None
+
+    hypothesis_analysis = _build_hypothesis_analysis(trials)
+    return summary, hypothesis_analysis
+
+
+def _support3_rate_for_gap(
+    trials: list[dict[str, Any]],
+    *,
+    lower: float | None,
+    upper: float | None,
+) -> float | None:
+    filtered = [
+        t
+        for t in trials
+        if t["dominant_gap"] is not None
+        and (lower is None or float(t["dominant_gap"]) >= lower)
+        and (upper is None or float(t["dominant_gap"]) < upper)
+    ]
+    if not filtered:
+        return None
+    return float(sum(1 for t in filtered if bool(t["is_support_3"])) / len(filtered))
+
+
+def _build_hypothesis_analysis(trials: list[dict[str, Any]]) -> dict[str, Any]:
+    gap_bins = [
+        (1.0, 1.2, "[1.0,1.2)"),
+        (1.2, 1.5, "[1.2,1.5)"),
+        (1.5, 2.0, "[1.5,2.0)"),
+        (2.0, 3.0, "[2.0,3.0)"),
+        (3.0, None, "[3.0,inf)"),
+    ]
+
+    bin_results: list[dict[str, Any]] = []
+    defined_trials = [t for t in trials if t["dominant_gap"] is not None]
+    for lower, upper, label in gap_bins:
+        bucket = [
+            t
+            for t in defined_trials
+            if float(t["dominant_gap"]) >= lower and (upper is None or float(t["dominant_gap"]) < upper)
+        ]
+        count = len(bucket)
+        support3_rate = float(sum(1 for t in bucket if bool(t["is_support_3"])) / count) if count > 0 else None
+        mean_support_size = float(np.mean([int(t["support_size"]) for t in bucket])) if count > 0 else None
+        bin_results.append(
+            {
+                "bin": label,
+                "count": count,
+                "support3_rate": support3_rate,
+                "mean_support_size": mean_support_size,
+            }
+        )
+
+    overall_support3_rate = (
+        float(sum(1 for t in defined_trials if bool(t["is_support_3"])) / len(defined_trials))
+        if defined_trials
+        else None
+    )
+
+    return {
+        "gap_bins": bin_results,
+        "overall_support3_rate": overall_support3_rate,
+    }
+
+
+def _write_trials_csv(path: Path, trials: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [
+        "trial",
+        "lambda1",
+        "lambda2",
+        "lambda3",
+        "ratio2_to_1",
+        "ratio3_to_1",
+        "dominant_gap",
+        "support_size",
+        "is_support_3",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for t in trials:
+            writer.writerow(
+                {
+                    "trial": t["trial_index"],
+                    "lambda1": t["lambda1"],
+                    "lambda2": t["lambda2"],
+                    "lambda3": t["lambda3"],
+                    "ratio2_to_1": t["ratio2_to_1"],
+                    "ratio3_to_1": t["ratio3_to_1"],
+                    "dominant_gap": t["dominant_gap"],
+                    "support_size": t["support_size"],
+                    "is_support_3": t["is_support_3"],
+                }
+            )

--- a/tests/entrypoints/test_experiment_team_strict_spectrum.py
+++ b/tests/entrypoints/test_experiment_team_strict_spectrum.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import (
+    _build_hypothesis_analysis,
+    _summarize_trials,
+    _write_trials_csv,
+)
+
+
+def test_summarize_trials_adds_gap_hypothesis_metrics() -> None:
+    trials = [
+        {
+            "trial_index": 0,
+            "lambda1": 2.4,
+            "lambda2": 1.2,
+            "lambda3": 0.9,
+            "ratio2_to_1": 0.5,
+            "ratio3_to_1": 0.375,
+            "dominant_gap": 2.0,
+            "support_size": 3,
+            "is_support_3": True,
+        },
+        {
+            "trial_index": 1,
+            "lambda1": 1.4,
+            "lambda2": 1.0,
+            "lambda3": 0.6,
+            "ratio2_to_1": 0.714285,
+            "ratio3_to_1": 0.428571,
+            "dominant_gap": 1.4,
+            "support_size": 2,
+            "is_support_3": False,
+        },
+        {
+            "trial_index": 2,
+            "lambda1": 1.0,
+            "lambda2": None,
+            "lambda3": None,
+            "ratio2_to_1": None,
+            "ratio3_to_1": None,
+            "dominant_gap": None,
+            "support_size": 3,
+            "is_support_3": True,
+        },
+    ]
+
+    summary, hypothesis_analysis = _summarize_trials(trials)
+
+    assert summary["support3_rate_gap_ge_2"] == 1.0
+    assert summary["support3_rate_gap_lt_2"] == 0.0
+    assert summary["delta_support3_rate"] == 1.0
+    assert hypothesis_analysis["overall_support3_rate"] == 0.5
+
+
+def test_build_hypothesis_analysis_gap_bins() -> None:
+    trials = [
+        {"dominant_gap": 1.1, "support_size": 2, "is_support_3": False},
+        {"dominant_gap": 1.25, "support_size": 3, "is_support_3": True},
+        {"dominant_gap": 1.7, "support_size": 4, "is_support_3": False},
+        {"dominant_gap": 2.5, "support_size": 3, "is_support_3": True},
+        {"dominant_gap": 3.2, "support_size": 3, "is_support_3": True},
+        {"dominant_gap": None, "support_size": 3, "is_support_3": True},
+    ]
+
+    analysis = _build_hypothesis_analysis(trials)
+
+    bins = {entry["bin"]: entry for entry in analysis["gap_bins"]}
+    assert bins["[1.0,1.2)"]["count"] == 1
+    assert bins["[1.2,1.5)"]["count"] == 1
+    assert bins["[1.5,2.0)"]["count"] == 1
+    assert bins["[2.0,3.0)"]["count"] == 1
+    assert bins["[3.0,inf)"]["count"] == 1
+    assert analysis["overall_support3_rate"] == 0.6
+
+
+def test_write_trials_csv_columns(tmp_path) -> None:
+    output_csv = tmp_path / "team_strict_spectrum_trials.csv"
+    _write_trials_csv(
+        output_csv,
+        [
+            {
+                "trial_index": 7,
+                "lambda1": 3.0,
+                "lambda2": 2.0,
+                "lambda3": 1.0,
+                "ratio2_to_1": 2 / 3,
+                "ratio3_to_1": 1 / 3,
+                "dominant_gap": 1.5,
+                "support_size": 3,
+                "is_support_3": True,
+            }
+        ],
+    )
+
+    lines = output_csv.read_text(encoding="utf-8").strip().splitlines()
+    assert lines[0] == "trial,lambda1,lambda2,lambda3,ratio2_to_1,ratio3_to_1,dominant_gap,support_size,is_support_3"
+    assert lines[1].startswith("7,3.0,2.0,1.0,")


### PR DESCRIPTION
### Motivation
- Provide a required `dominant_gap` analysis (`lambda1/lambda2` when defined) to evaluate how the eigenvalue gap relates to support size and to enable downstream visualization.
- Aggregate trials by configured `dominant_gap` bins and surface simple hypothesis indicators (`support3_rate_gap_ge_2`, `support3_rate_gap_lt_2`, and their `delta_support3_rate`) for quick inspection.
- Export a per-trial CSV to make subsequent external analysis/visualization easier.

### Description
- Updated the run pipeline in `src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py` to write `output/team_strict_spectrum_trials.csv` and include a new `hypothesis_analysis` section in the output JSON alongside `summary`.
- Extended `_summarize_trials` to return `(summary, hypothesis_analysis)` and added `dominant_gap_mean`/`dominant_gap_std`, `support3_rate_gap_ge_2`, `support3_rate_gap_lt_2`, and `delta_support3_rate` to the `summary`.
- Implemented `_build_hypothesis_analysis` which bins trials by the gaps `[1.0,1.2), [1.2,1.5), [1.5,2.0), [2.0,3.0), [3.0,inf)` and computes per-bin `count`, `support3_rate`, and `mean_support_size`, plus `overall_support3_rate` (only trials where `dominant_gap` is defined).
- Added CSV writer `_write_trials_csv` that emits columns: `trial,lambda1,lambda2,lambda3,ratio2_to_1,ratio3_to_1,dominant_gap,support_size,is_support_3` and updated the run metadata to include the CSV in `output_files`.
- Added focused tests `tests/entrypoints/test_experiment_team_strict_spectrum.py` covering summary/hypothesis metrics, bin aggregation, and CSV column output.

### Testing
- Ran the project's test suite with `uv run pytest` which executed the full test suite (including the newly added tests) and succeeded: `263 passed, 3 warnings`.
- Unit tests added: `tests/entrypoints/test_experiment_team_strict_spectrum.py`, which validate binning results, summary indicators, and CSV format.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7c8a940883309a055c7842682f93)