### PR TITLE
Support character_count>=2 for team_strict_spectrum; add configs, run script, docs, and metrics

### DIFF
--- a/data/experiment/team_strict_spectrum/report16_50_baseline/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_50_baseline/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 50
+power_low = -1.0
+power_high = 1.0
+vector_low = -1.0
+vector_high = 1.0
+random_seed = 424242
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report16_50_power_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_50_power_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 50
+power_low = -2.0
+power_high = 2.0
+vector_low = -0.5
+vector_high = 0.5
+random_seed = 424243
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report16_50_vector_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_50_vector_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 50
+power_low = -0.5
+power_high = 0.5
+vector_low = -2.0
+vector_high = 2.0
+random_seed = 424244
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report16_baseline/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_baseline/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 3
+power_low = -1.0
+power_high = 1.0
+vector_low = -1.0
+vector_high = 1.0
+random_seed = 424242
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report16_power_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_power_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 3
+power_low = -2.0
+power_high = 2.0
+vector_low = -0.5
+vector_high = 0.5
+random_seed = 424243
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report16_vector_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report16_vector_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 16
+team_size = 2
+generation_count = 3
+power_low = -0.5
+power_high = 0.5
+vector_low = -2.0
+vector_high = 2.0
+random_seed = 424244
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report_baseline/data.toml
+++ b/data/experiment/team_strict_spectrum/report_baseline/data.toml
@@ -1,0 +1,9 @@
+character_count = 6
+team_size = 2
+generation_count = 50
+power_low = -1.0
+power_high = 1.0
+vector_low = -1.0
+vector_high = 1.0
+random_seed = 42
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report_power_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report_power_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 6
+team_size = 2
+generation_count = 50
+power_low = -2.0
+power_high = 2.0
+vector_low = -0.5
+vector_high = 0.5
+random_seed = 4242
+support_threshold = 1e-6

--- a/data/experiment/team_strict_spectrum/report_vector_wide/data.toml
+++ b/data/experiment/team_strict_spectrum/report_vector_wide/data.toml
@@ -1,0 +1,9 @@
+character_count = 6
+team_size = 2
+generation_count = 50
+power_low = -0.5
+power_high = 0.5
+vector_low = -2.0
+vector_high = 2.0
+random_seed = 7
+support_threshold = 1e-6

--- a/data/run_config/experiment_team_strict_spectrum_report16_50_baseline.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_50_baseline.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_50_baseline"

--- a/data/run_config/experiment_team_strict_spectrum_report16_50_power_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_50_power_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_50_power_wide"

--- a/data/run_config/experiment_team_strict_spectrum_report16_50_vector_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_50_vector_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_50_vector_wide"

--- a/data/run_config/experiment_team_strict_spectrum_report16_baseline.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_baseline.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_baseline"

--- a/data/run_config/experiment_team_strict_spectrum_report16_power_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_power_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_power_wide"

--- a/data/run_config/experiment_team_strict_spectrum_report16_vector_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report16_vector_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report16_vector_wide"

--- a/data/run_config/experiment_team_strict_spectrum_report_baseline.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report_baseline.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report_baseline"

--- a/data/run_config/experiment_team_strict_spectrum_report_power_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report_power_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report_power_wide"

--- a/data/run_config/experiment_team_strict_spectrum_report_vector_wide.toml
+++ b/data/run_config/experiment_team_strict_spectrum_report_vector_wide.toml
@@ -1,0 +1,7 @@
+features = ["experiment_team_strict_spectrum"]
+
+[shared]
+setting = "local"
+
+[experiment_team_strict_spectrum]
+experiment = "report_vector_wide"

--- a/document/experiment/team_strict_spectrum_char16_gen50_runbook_2026-04-02.md
+++ b/document/experiment/team_strict_spectrum_char16_gen50_runbook_2026-04-02.md
@@ -1,0 +1,45 @@
+# team_strict_spectrum 16キャラ×50試行 実行Runbook（2026-04-02）
+
+このドキュメントは、`character_count=16` かつ `generation_count=50` の3条件実験を、
+`git clone` 後すぐ実行できるように手順をまとめたものです。
+
+## 追加済み設定ファイル
+
+- baseline
+  - `data/experiment/team_strict_spectrum/report16_50_baseline/data.toml`
+  - `data/run_config/experiment_team_strict_spectrum_report16_50_baseline.toml`
+- power_wide
+  - `data/experiment/team_strict_spectrum/report16_50_power_wide/data.toml`
+  - `data/run_config/experiment_team_strict_spectrum_report16_50_power_wide.toml`
+- vector_wide
+  - `data/experiment/team_strict_spectrum/report16_50_vector_wide/data.toml`
+  - `data/run_config/experiment_team_strict_spectrum_report16_50_vector_wide.toml`
+
+## 実行方法（推奨）
+
+### 1) 依存関係
+
+```bash
+uv sync
+```
+
+### 2) 3条件を連続実行
+
+```bash
+uv run python scripts/run_team_strict_spectrum_report16_gen50.py
+```
+
+### 3) 1条件だけ実行
+
+```bash
+uv run python scripts/run_team_strict_spectrum_report16_gen50.py --only baseline
+uv run python scripts/run_team_strict_spectrum_report16_gen50.py --only power_wide
+uv run python scripts/run_team_strict_spectrum_report16_gen50.py --only vector_wide
+```
+
+## 補足
+
+- 以前の `character_count=16, generation_count=3` 実行時の観測では、おおむね **1試行 ≒ 20秒**。
+- そのため、`generation_count=50` は **1条件あたり約1000秒（約16〜17分）**、3条件合計で約50分を見込んでください。
+- 出力は `results/<run_id>/output/team_strict_spectrum_experiment.json` に保存されます。
+

--- a/document/experiment/team_strict_spectrum_char16_gen50_runbook_2026-04-02.md
+++ b/document/experiment/team_strict_spectrum_char16_gen50_runbook_2026-04-02.md
@@ -41,5 +41,7 @@ uv run python scripts/run_team_strict_spectrum_report16_gen50.py --only vector_w
 
 - 以前の `character_count=16, generation_count=3` 実行時の観測では、おおむね **1試行 ≒ 20秒**。
 - そのため、`generation_count=50` は **1条件あたり約1000秒（約16〜17分）**、3条件合計で約50分を見込んでください。
-- 出力は `results/<run_id>/output/team_strict_spectrum_experiment.json` に保存されます。
-
+- 各条件は別runとして保存されるため、出力は `results/<run_id>/output/team_strict_spectrum_experiment.json` が3つ作られます（1ファイルに追記されません）。
+- スクリプトは3条件分の集約JSONも書き出します。
+  - `results/team_strict_spectrum_report16_gen50_latest.json`
+  - `results/team_strict_spectrum_report16_gen50_<timestamp>.json`

--- a/document/experiment/team_strict_spectrum_random_character_report_2026-04-02.md
+++ b/document/experiment/team_strict_spectrum_random_character_report_2026-04-02.md
@@ -1,0 +1,84 @@
+# ランダムキャラクター生成による構築相性スペクトラム実験レポート（2026-04-02）
+
+## 目的
+
+ランダム生成した6キャラクター（各キャラに `p` と2次元 `v`）から `team = "strict"` の構築相性行列（15x15）を作り、次を確認する。
+
+1. 構築相性行列の固有値スペクトラム（主要固有値比、dominant gap）
+2. ナッシュ均衡の support size（**support size ≤ 3** を主指標に確認）
+3. `team = "strict"` で作る構築行列が「最大固有値突出 & support size ≤ 3 になりやすいか」の確認
+
+## 実験条件
+
+`experiment_team_strict_spectrum` feature を3条件で起動した。
+
+- Baseline: `p∈[-1,1]`, `v∈[-1,1]`, seed=42
+- Power wide: `p∈[-2,2]`, `v∈[-0.5,0.5]`, seed=4242
+- Vector wide: `p∈[-0.5,0.5]`, `v∈[-2,2]`, seed=7
+
+すべて `character_count=6`, `team_size=2`, `generation_count=50`。
+
+## 実行コマンド（時間測定あり）
+
+```bash
+uv run python - <<'PY'
+import time
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import run
+from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
+cfgs=[
+('baseline','data/run_config/experiment_team_strict_spectrum_report_baseline.toml'),
+('power_wide','data/run_config/experiment_team_strict_spectrum_report_power_wide.toml'),
+('vector_wide','data/run_config/experiment_team_strict_spectrum_report_vector_wide.toml'),
+]
+for name,cfg in cfgs:
+    t0 = time.perf_counter()
+    code = run(MainConfigLoader(cfg))
+    elapsed = time.perf_counter() - t0
+    if code != 0:
+        raise SystemExit(f'failed: {name}')
+    print(name, f"{elapsed:.3f}s")
+PY
+```
+
+出力 run_id:
+
+- baseline: `results/1`
+- power_wide: `results/2`
+- vector_wide: `results/3`
+
+## 結果サマリ
+
+| 条件 | 実行時間[s] | dominant_gap_mean | ratio2_to_1_mean | support size ヒストグラム | support_size=3率 | support_size≤3率 | corr(gap, support_size) |
+|---|---:|---:|---:|---|---:|---:|---:|
+| baseline | 21.062 | 5.243 | 0.295 | {1: 38, 3: 12} | 0.24 | 1.00 | -0.365 |
+| power_wide | 20.874 | 58.835 | 0.044 | {1: 50} | 0.00 | 1.00 | n/a |
+| vector_wide | 21.476 | 7.353 | 0.293 | {1: 18, 3: 29, 5: 3} | 0.58 | 0.94 | -0.520 |
+
+## 観察
+
+- 3条件とも実行時間は約21秒/50試行（≒0.42秒/試行）で、時間制約下でも50試行までは回せる。
+- **Power wide 条件**では、dominant gap が極端に大きく（平均58.84）、均衡 support はすべて1点支持（support≤3率=100%）。
+- **Baseline 条件**も support は {1,3} のみで、support≤3率=100%。
+- **Vector wide 条件**でも support≤3率は94%で、support=5 は3/50件に留まる。
+
+## 仮説に対する考察
+
+本実験の主眼（`team = "strict"` の構築行列では「最大固有値突出 & support size≤3 になりやすいか」）に対しては、**肯定的な結果**だった。
+
+- 3条件とも support≤3 率が非常に高い（100%, 100%, 94%）。
+- 特に最大固有値が強く突出した power_wide 条件は、support=1 に完全収束した。
+- 条件内相関は負側（baseline -0.365, vector_wide -0.520）で、「突出すると support=3 が増える」というより、**突出が強いほど support が小さくなる（より疎になる）**挙動が示唆された。
+
+従って今回の設定範囲では、
+
+- `team = "strict"` で生成される構築行列は support size≤3 を取りやすい。
+- `v` の振れ幅を大きくすると（vector_wide）まれに support>3 が出るが、依然として少数。
+
+## 制約と次アクション
+
+今回は試行数を 10 → 50 へ増やしたが、統計的に十分とは言い切れない。次を推奨する。
+
+1. 各条件を `generation_count=100~500` へ拡大（想定時間: 約0.42秒/試行）
+2. seed を複数（例: 10本）回して平均化
+3. `support_size<=3` を目的変数にしたロジスティック回帰（説明変数: dominant_gap, ratio2_to_1, ratio3_to_1, p/v の分散）
+

--- a/document/experiment/team_strict_spectrum_random_character_report_char16_2026-04-02.md
+++ b/document/experiment/team_strict_spectrum_random_character_report_char16_2026-04-02.md
@@ -1,0 +1,85 @@
+# ランダムキャラクター生成による構築相性スペクトラム実験レポート（character_count=16, 2026-04-02）
+
+## 目的
+
+`character_count=16`（`team_size=2`）に拡張したときも、`team = "strict"` の構築行列が
+
+- 最大固有値の突出（dominant gapの大きさ）
+- 均衡 support size の小ささ（特に support size ≤ 3）
+
+を維持するか確認する。
+
+## 実験条件
+
+3条件（6キャラ版と同じレンジ設計）で比較。
+
+- baseline16: `p∈[-1,1]`, `v∈[-1,1]`, seed=424242
+- power_wide16: `p∈[-2,2]`, `v∈[-0.5,0.5]`, seed=424243
+- vector_wide16: `p∈[-0.5,0.5]`, `v∈[-2,2]`, seed=424244
+
+共通設定: `character_count=16`, `team_size=2`, `generation_count=3`。
+
+> 16キャラでは1試行あたり計算時間が長いため、まずは時間計測込みの小規模試行で挙動確認を優先。
+
+## 実行コマンド（時間測定あり）
+
+```bash
+uv run python - <<'PY'
+import json, time
+from pathlib import Path
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import run
+from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
+
+cfgs=[
+('baseline16','data/run_config/experiment_team_strict_spectrum_report16_baseline.toml'),
+('power_wide16','data/run_config/experiment_team_strict_spectrum_report16_power_wide.toml'),
+('vector_wide16','data/run_config/experiment_team_strict_spectrum_report16_vector_wide.toml'),
+]
+base=Path('results')
+known={p.name for p in base.iterdir()} if base.exists() else set()
+for name,cfg in cfgs:
+    t0=time.perf_counter()
+    code=run(MainConfigLoader(cfg))
+    elapsed=time.perf_counter()-t0
+    if code!=0:
+        raise SystemExit(f'failed: {name}')
+    now={p.name for p in base.iterdir()}
+    rid=sorted(now-known, key=lambda x:int(x))[-1]
+    known=now
+    print(name, rid, f"{elapsed:.3f}s")
+PY
+```
+
+出力 run_id:
+
+- baseline16: `results/1`
+- power_wide16: `results/2`
+- vector_wide16: `results/3`
+
+## 結果サマリ
+
+| 条件 | 実行時間[s] | dominant_gap_mean | ratio2_to_1_mean | support size ヒストグラム | support_size=3率 | support_size≤3率 | corr(gap, support_size) |
+|---|---:|---:|---:|---|---:|---:|---:|
+| baseline16 | 60.763 | 2.720 | 0.374 | {1: 1, 3: 2} | 0.667 | 1.000 | -0.977 |
+| power_wide16 | 59.833 | 10.591 | 0.094 | {1: 3} | 0.000 | 1.000 | n/a |
+| vector_wide16 | 61.160 | 2.123 | 0.474 | {3: 2, 5: 1} | 0.667 | 0.667 | -0.217 |
+
+## 観察
+
+- 実行時間は各条件とも約60秒/3試行（≒20秒/試行）。
+- baseline16 と power_wide16 は support size ≤ 3 が 100%。
+- power_wide16 は support=1 に集中し、最大固有値突出（dominant gap高め）と疎な支持が同時に出る。
+- vector_wide16 では support=5 が1件出て、`v` の広がり増加時に support>3 が出る傾向は6キャラ版と同方向。
+
+## 考察
+
+`character_count=16` でも、少なくとも今回の3条件では「`team = "strict"` で support size ≤ 3 になりやすい」傾向は維持された。
+
+一方で試行数が3と少ないため、統計的な結論よりも**挙動確認（スモーク的検証）**の意味合いが強い。時間見積りは取れたため、次段階は計算資源と相談しつつ試行数を増やす。
+
+## 次アクション
+
+1. `generation_count=10` まで拡張（1条件あたり約200秒見込み）
+2. まず baseline16 / power_wide16 の2条件を優先して統計を安定化
+3. 計算時間短縮が必要なら、ソルバ選択・早期打ち切り条件・並列化を検討
+

--- a/scripts/run_team_strict_spectrum_report16_gen50.py
+++ b/scripts/run_team_strict_spectrum_report16_gen50.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+
+from monocycle_nash.analysis.app.experiment_team_strict_spectrum import run
+from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
+
+
+@dataclass(frozen=True)
+class RunTarget:
+    name: str
+    config_path: str
+
+
+TARGETS: tuple[RunTarget, ...] = (
+    RunTarget("baseline", "data/run_config/experiment_team_strict_spectrum_report16_50_baseline.toml"),
+    RunTarget("power_wide", "data/run_config/experiment_team_strict_spectrum_report16_50_power_wide.toml"),
+    RunTarget("vector_wide", "data/run_config/experiment_team_strict_spectrum_report16_50_vector_wide.toml"),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run character_count=16, generation_count=50 strict-spectrum experiments.",
+    )
+    parser.add_argument(
+        "--only",
+        choices=[t.name for t in TARGETS],
+        help="Run only one condition.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    targets = [t for t in TARGETS if args.only in (None, t.name)]
+
+    for target in targets:
+        started = time.perf_counter()
+        code = run(MainConfigLoader(target.config_path))
+        elapsed = time.perf_counter() - started
+        print(f"[{target.name}] code={code} elapsed_sec={elapsed:.3f} config={target.config_path}")
+        if code != 0:
+            return code
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_team_strict_spectrum_report16_gen50.py
+++ b/scripts/run_team_strict_spectrum_report16_gen50.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import json
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
 
 from monocycle_nash.analysis.app.experiment_team_strict_spectrum import run
 from monocycle_nash.runtime.infra.loader.main_config import MainConfigLoader
@@ -30,20 +33,76 @@ def parse_args() -> argparse.Namespace:
         choices=[t.name for t in TARGETS],
         help="Run only one condition.",
     )
+    parser.add_argument(
+        "--results-dir",
+        default="results",
+        help="Directory where run outputs are written (default: results).",
+    )
     return parser.parse_args()
+
+
+def _list_run_ids(results_dir: Path) -> set[int]:
+    if not results_dir.exists():
+        return set()
+    run_ids: set[int] = set()
+    for child in results_dir.iterdir():
+        if child.is_dir() and child.name.isdigit():
+            run_ids.add(int(child.name))
+    return run_ids
+
+
+def _load_experiment_summary(results_dir: Path, run_id: int) -> dict:
+    path = results_dir / str(run_id) / "output" / "team_strict_spectrum_experiment.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload["summary"]
 
 
 def main() -> int:
     args = parse_args()
     targets = [t for t in TARGETS if args.only in (None, t.name)]
+    results_dir = Path(args.results_dir)
+    records: list[dict] = []
 
     for target in targets:
+        before = _list_run_ids(results_dir)
         started = time.perf_counter()
         code = run(MainConfigLoader(target.config_path))
         elapsed = time.perf_counter() - started
-        print(f"[{target.name}] code={code} elapsed_sec={elapsed:.3f} config={target.config_path}")
+        after = _list_run_ids(results_dir)
+        created = sorted(after - before)
+        run_id = created[-1] if created else None
+        summary = _load_experiment_summary(results_dir, run_id) if run_id is not None else None
+
+        print(
+            f"[{target.name}] code={code} elapsed_sec={elapsed:.3f} "
+            f"run_id={run_id} config={target.config_path}"
+        )
+        records.append(
+            {
+                "target": target.name,
+                "config_path": target.config_path,
+                "code": code,
+                "elapsed_sec": elapsed,
+                "run_id": run_id,
+                "summary": summary,
+            }
+        )
         if code != 0:
             return code
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    aggregate = {
+        "script": "run_team_strict_spectrum_report16_gen50.py",
+        "created_at_utc": timestamp,
+        "records": records,
+    }
+    out_latest = results_dir / "team_strict_spectrum_report16_gen50_latest.json"
+    out_timestamped = results_dir / f"team_strict_spectrum_report16_gen50_{timestamp}.json"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    out_latest.write_text(json.dumps(aggregate, ensure_ascii=False, indent=2), encoding="utf-8")
+    out_timestamped.write_text(json.dumps(aggregate, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"aggregate_written={out_latest}")
+    print(f"aggregate_written={out_timestamped}")
     return 0
 
 

--- a/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
+++ b/src/monocycle_nash/analysis/app/experiment_team_strict_spectrum.py
@@ -150,8 +150,8 @@ def _run_single_trial(
 
 
 def _build_matrix_input(rng: np.random.Generator, settings: TeamStrictExperimentSettings) -> dict[str, Any]:
-    if settings.character_count != 6:
-        raise ValueError("experiment_team_strict_spectrum.character_count は 6 固定です")
+    if settings.character_count < 2:
+        raise ValueError("experiment_team_strict_spectrum.character_count は 2 以上で指定してください")
     if settings.team_size != 2:
         raise ValueError("experiment_team_strict_spectrum.team_size は 2 固定です")
 
@@ -225,6 +225,11 @@ def _summarize_trials(trials: list[dict[str, Any]]) -> tuple[dict[str, Any], dic
         if count > 0
         else None
     )
+    support_size_le_3_rate = (
+        float(sum(1 for size in support_sizes if size <= 3) / count)
+        if count > 0
+        else None
+    )
 
     summary = {
         "count": count,
@@ -236,6 +241,8 @@ def _summarize_trials(trials: list[dict[str, Any]]) -> tuple[dict[str, Any], dic
         "dominant_gap_std": float(np.std(dominant_gap_values)) if dominant_gap_values else None,
         "support_size_histogram": histogram,
         "support_size_eq_3_rate": support_size_eq_3_rate,
+        "support_size_le_3_rate": support_size_le_3_rate,
+        "support_size_gt_3_rate": (1.0 - support_size_le_3_rate) if support_size_le_3_rate is not None else None,
         "corr_dominant_gap_vs_support_size": corr,
         "support3_rate_gap_ge_2": _support3_rate_for_gap(trials, lower=2.0, upper=None),
         "support3_rate_gap_lt_2": _support3_rate_for_gap(trials, lower=None, upper=2.0),

--- a/src/monocycle_nash/analysis/infra/approximation.py
+++ b/src/monocycle_nash/analysis/infra/approximation.py
@@ -158,8 +158,8 @@ def _build_team_strict_experiment_settings(data: dict) -> TeamStrictExperimentSe
         support_threshold=_required_float(data, key="support_threshold", default=1e-6),
         solver=_optional_str(data, key="solver", default=""),
     )
-    if settings.character_count != 6:
-        raise ValueError("experiment_team_strict_spectrum.character_count は 6 で指定してください")
+    if settings.character_count < 2:
+        raise ValueError("experiment_team_strict_spectrum.character_count は 2 以上で指定してください")
     if settings.team_size != 2:
         raise ValueError("experiment_team_strict_spectrum.team_size は 2 で指定してください")
     if settings.generation_count <= 0:

--- a/tests/entrypoints/test_experiment_team_strict_spectrum.py
+++ b/tests/entrypoints/test_experiment_team_strict_spectrum.py
@@ -45,6 +45,8 @@ def _write_experiment(
     data_dir: Path,
     *,
     name: str,
+    character_count: int = 6,
+    team_size: int = 2,
     generation_count: int = 5,
     power_low: float = -1.0,
     power_high: float = 1.0,
@@ -54,6 +56,8 @@ def _write_experiment(
     _write(
         data_dir / "experiment" / "team_strict_spectrum" / name / "data.toml",
         f'''
+        character_count = {character_count}
+        team_size = {team_size}
         generation_count = {generation_count}
         power_low = {power_low}
         power_high = {power_high}
@@ -89,6 +93,7 @@ def test_experiment_team_strict_spectrum_writes_result_json(tmp_path: Path) -> N
         assert "support_size" in trial
 
     assert "support_size_histogram" in payload["summary"]
+    assert "support_size_le_3_rate" in payload["summary"]
 
 
 def test_experiment_team_strict_spectrum_fails_when_generation_count_is_non_positive(tmp_path: Path) -> None:
@@ -128,6 +133,22 @@ def test_experiment_team_strict_spectrum_fails_for_invalid_vector_range(tmp_path
         generation_count=5,
         vector_low=0.5,
         vector_high=0.5,
+    )
+    _write_setting(data_dir, tmp_path)
+
+    code = run(MainConfigLoader(data_dir / "run_config" / "main.toml"))
+
+    assert code == 1
+
+
+def test_experiment_team_strict_spectrum_fails_for_invalid_character_count(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _write_main_config(data_dir, experiment_name="invalid_character_count")
+    _write_experiment(
+        data_dir,
+        name="invalid_character_count",
+        character_count=1,
+        generation_count=1,
     )
     _write_setting(data_dir, tmp_path)
 


### PR DESCRIPTION
### Motivation

- Enable running `team_strict_spectrum` experiments with character counts other than 6 (e.g. 16) and provide ready-to-run configs and runbooks for larger experiments. 
- Provide a clearer summary metric for how often supports are small by adding a "≤3" support-rate statistic. 
- Add convenience scripts and run_config/data payloads to standardize repeatable experiment runs (baseline / power_wide / vector_wide).

### Description

- Relaxed the hard requirement of `character_count == 6` to accept any `character_count >= 2` in `_build_matrix_input` and `_build_team_strict_experiment_settings` so experiments can run with 16 characters. 
- Added new summary fields `support_size_le_3_rate` and `support_size_gt_3_rate` to the experiment summary and preserved existing correlation and gap-based analyses. 
- Added many new data payloads and run_config TOML files under `data/experiment/team_strict_spectrum` and `data/run_config/` for baseline/power_wide/vector_wide with both 6- and 16-character settings and generation_count variants (3 and 50). 
- Added `scripts/run_team_strict_spectrum_report16_gen50.py` to run the three 16-character experiments sequentially, plus runbook documents in `document/experiment/` describing how to run and interpret the experiments. 
- Updated tests in `tests/entrypoints/test_experiment_team_strict_spectrum.py` to parametrize `character_count`, assert the new `support_size_le_3_rate` summary key, and include a new test that verifies failure when `character_count < 2`.

### Testing

- Added and updated unit tests in `tests/entrypoints/test_experiment_team_strict_spectrum.py` including the new `test_experiment_team_strict_spectrum_fails_for_invalid_character_count`; ran `pytest tests/entrypoints/test_experiment_team_strict_spectrum.py`. 
- All tests in that module executed successfully (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce83ddced88330b37fa1eaeeee264e)