### PR TITLE
利得行列JSON出力機能の追加

### DIFF
--- a/src/monocycle_nash/application/matrix_nodes.py
+++ b/src/monocycle_nash/application/matrix_nodes.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import numpy as np
 import tomli_w
@@ -727,6 +728,83 @@ class EquilibriumOutputNode(OutputNode["MatrixNode"], output_method="equilibrium
                     ],
                 },
                 f,
+            )
+        return path
+
+
+@dataclass(frozen=True)
+class PayoffMatrixOutputNode(OutputNode["MatrixNode"], output_method="payoff_matrix"):
+    """利得行列ファイル出力設定ノード。"""
+
+    runner: str | None = None
+    filename: str = "payoff_matrix.json"
+    rows: tuple[int, ...] | None = None
+    cols: tuple[int, ...] | None = None
+
+    @classmethod
+    def _from_output_spec(cls, spec: OutputSpec) -> PayoffMatrixOutputNode:
+        rows = spec.params.get("rows")
+        cols = spec.params.get("cols")
+        return cls(
+            runner=spec.runner,
+            filename=spec.params.get("filename", "payoff_matrix.json"),
+            rows=tuple(rows) if rows is not None else None,
+            cols=tuple(cols) if cols is not None else None,
+        )
+
+    def emit(
+        self,
+        *,
+        node_name: str,
+        node_path: tuple[str, ...],
+        node: "MatrixNode",
+    ) -> OutputEmission:
+        return OutputEmission(
+            output_node=self,
+            node_name=node_name,
+            node_path=node_path,
+            runner=self.runner,
+            node=node,
+        )
+
+    def execute(
+        self,
+        *,
+        output_path_port: OutputPathPort,
+        run_id: str,
+        node_path: tuple[str, ...],
+        node: "MatrixNode",
+        ctx: NodeResolutionContext,
+    ) -> Path:
+        path = output_path_port.resolve_output_path(
+            run_id=run_id,
+            node_path=node_path,
+            output_method=self.output_method,
+            filename=self.filename,
+        )
+        matrix_obj = node.provide_object(ctx=ctx)
+        matrix = matrix_obj.matrix
+        row_labels = matrix_obj.row_strategies.labels
+        col_labels = matrix_obj.col_strategies.labels
+
+        if self.rows is not None:
+            matrix = matrix[list(self.rows), :]
+            row_labels = [row_labels[i] for i in self.rows]
+        if self.cols is not None:
+            matrix = matrix[:, list(self.cols)]
+            col_labels = [col_labels[i] for i in self.cols]
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "matrix": matrix.tolist(),
+                    "row_labels": row_labels,
+                    "col_labels": col_labels,
+                },
+                f,
+                indent=2,
+                ensure_ascii=False,
             )
         return path
 

--- a/tests/application/test_payoff_matrix_output.py
+++ b/tests/application/test_payoff_matrix_output.py
@@ -1,0 +1,127 @@
+import json
+import numpy as np
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from monocycle_nash.application.matrix_nodes import (
+    PayoffMatrixOutputNode,
+    MatrixNode,
+    NodeResolutionContext,
+)
+from monocycle_nash.application.node_spec import OutputSpec
+from monocycle_nash.application.ports import OutputPathPort
+from monocycle_nash.domain.matrix.base import PayoffMatrix
+from monocycle_nash.domain.strategy import PureStrategySet
+
+
+class MockPayoffMatrix(PayoffMatrix):
+    def __init__(self, matrix, row_labels, col_labels):
+        self._matrix = np.asarray(matrix)
+        self._row_strategies = PureStrategySet.from_labels(row_labels)
+        self._col_strategies = PureStrategySet.from_labels(col_labels)
+
+    @property
+    def matrix(self) -> np.ndarray:
+        return self._matrix
+
+    @property
+    def size(self) -> int:
+        return self._matrix.shape[0]
+
+    @property
+    def row_strategies(self) -> PureStrategySet:
+        return self._row_strategies
+
+    @property
+    def col_strategies(self) -> PureStrategySet:
+        return self._col_strategies
+
+
+def test_payoff_matrix_output_full(tmp_path: Path):
+    # Setup
+    matrix_data = [[0.0, 1.0], [-1.0, 0.0]]
+    row_labels = ["R1", "R2"]
+    col_labels = ["C1", "C2"]
+    mock_matrix = MockPayoffMatrix(matrix_data, row_labels, col_labels)
+
+    node = MagicMock(spec=MatrixNode)
+    node.provide_object.return_value = mock_matrix
+
+    ctx = MagicMock(spec=NodeResolutionContext)
+
+    port = MagicMock(spec=OutputPathPort)
+    output_file = tmp_path / "output.json"
+    port.resolve_output_path.return_value = output_file
+
+    spec = OutputSpec(method="payoff_matrix", params={"filename": "output.json"})
+    output_node = PayoffMatrixOutputNode.create_from_spec(spec)
+
+    # Execute
+    res_path = output_node.execute(
+        output_path_port=port,
+        run_id="run1",
+        node_path=("root",),
+        node=node,
+        ctx=ctx
+    )
+
+    # Verify
+    assert res_path == output_file
+    with open(output_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert data["matrix"] == matrix_data
+    assert data["row_labels"] == row_labels
+    assert data["col_labels"] == col_labels
+
+
+def test_payoff_matrix_output_sliced(tmp_path: Path):
+    # Setup
+    matrix_data = [
+        [0.0, 1.0, 2.0],
+        [-1.0, 0.0, 1.0],
+        [-2.0, -1.0, 0.0]
+    ]
+    row_labels = ["R1", "R2", "R3"]
+    col_labels = ["C1", "C2", "C3"]
+    mock_matrix = MockPayoffMatrix(matrix_data, row_labels, col_labels)
+
+    node = MagicMock(spec=MatrixNode)
+    node.provide_object.return_value = mock_matrix
+
+    ctx = MagicMock(spec=NodeResolutionContext)
+
+    port = MagicMock(spec=OutputPathPort)
+    output_file = tmp_path / "sliced.json"
+    port.resolve_output_path.return_value = output_file
+
+    spec = OutputSpec(
+        method="payoff_matrix",
+        params={
+            "filename": "sliced.json",
+            "rows": [0, 2],
+            "cols": [1]
+        }
+    )
+    output_node = PayoffMatrixOutputNode.create_from_spec(spec)
+
+    # Execute
+    output_node.execute(
+        output_path_port=port,
+        run_id="run1",
+        node_path=("root",),
+        node=node,
+        ctx=ctx
+    )
+
+    # Verify
+    with open(output_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # row 0,2 and col 1
+    # [0.0, 1.0, 2.0] -> index 1 is 1.0
+    # [-2.0, -1.0, 0.0] -> index 1 is -1.0
+    assert data["matrix"] == [[1.0], [-1.0]]
+    assert data["row_labels"] == ["R1", "R3"]
+    assert data["col_labels"] == ["C2"]


### PR DESCRIPTION
利得行列をJSON形式で出力する `payoff_matrix` 出力ノードを追加しました。

主な変更点:
- `src/monocycle_nash/application/matrix_nodes.py` に `PayoffMatrixOutputNode` クラスを追加。
- 行・列のインデックス指定によるスライス出力機能を実装。
- 行・列のラベル（戦略名）も併せて出力するように実装。
- 新規出力ノードの動作を検証するテストコード `tests/application/test_payoff_matrix_output.py` を追加。

JSON形式を採用したことで、冗長性を抑えつつ、戦略ラベルを含む完全な行列データ、あるいは指定した一部分のデータを容易にエクスポートできるようになりました。

---
*PR created automatically by Jules for task [13970216730324325655](https://jules.google.com/task/13970216730324325655) started by @pyran19*