### PR TITLE
行列出力ノードおよび均衡解出力ノードのドキュメント反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ runner = "..."                  # 任意（同名 runner で最終集約）
 - `equilibrium`
   - 任意パラメータ: `filename`
   - 均衡解を `strategies = [{ id, probability }, ...]` 形式のTOMLで出力
+- `payoff_matrix`
+  - 任意パラメータ: `filename`, `rows`, `cols`
+  - 利得行列を JSON 形式で出力。`rows`, `cols` でインデックス指定による抽出が可能
 - `team_matchup_experiment_csv`
   - 任意パラメータ: `filename`, `focus_team`
   - `general_from_team_matchups` ノードで、固定チーム i と各チーム j の比較実験列（ベクトル差・角度・Bij）を CSV 出力

--- a/document/readme/toml_config.md
+++ b/document/readme/toml_config.md
@@ -231,6 +231,20 @@ theta_step_deg = 90.0
   - `outputs.params.canvas_size`（既定: `840`）
   - `outputs.params.margin`（既定: `90`）
 
+### `equilibrium`
+
+- 任意:
+  - `outputs.params.filename`（既定: `"equilibrium.toml"`）
+- 均衡解を計算し、`strategies = [{ id, probability }, ...]` 形式の TOML で出力する。
+
+### `payoff_matrix`
+
+- 任意:
+  - `outputs.params.filename`（既定: `"payoff_matrix.json"`）
+  - `outputs.params.rows`（既定: 全行）
+  - `outputs.params.cols`（既定: 全列）
+- 利得行列を JSON 形式で出力する。`rows`, `cols` にインデックスのリストを指定することで、特定の行や列のみを抽出して出力できる。
+
 ### `team_matchup_experiment_csv`
 
 - 対象ノード: `general_from_team_matchups`


### PR DESCRIPTION
行列ノードから行列の値をそのまま出力する `payoff_matrix` 出力ノードのドキュメントを README.md および document/readme/toml_config.md に追加しました。また、toml_config.md に記載が漏れていた `equilibrium`（均衡解出力）のドキュメントも併せて追記しました。

---
*PR created automatically by Jules for task [3907098030340221424](https://jules.google.com/task/3907098030340221424) started by @pyran19*