### PR TITLE
CharacterRotatingPairSource の座標計算式の修正（sin/cos入れ替え）

### DIFF
--- a/document/readme/toml_config.md
+++ b/document/readme/toml_config.md
@@ -137,7 +137,7 @@ runner = "..."                # 任意: 同一 runner 名で最終集約
 
 ### `character_rotating_pair`（`children.characters` 用）
 
-`v1=(x,0)`,`v2=(0,y)` を固定し、`v3=(r3*sinθ, r3*cosθ)`,`v4=(r4*sin(d+θ), r4*cos(d+θ))` の2点を θ を進めながら1周ぶん生成する。`general_from_team_matchups` で固定構築 vs 回転構築の実験データを作る用途を想定。
+`v1=(x,0)`,`v2=(0,y)` を固定し、`v3=(r3*cosθ, r3*sinθ)`,`v4=(r4*cos(θ+d), r4*sin(θ+d))` の2点を θ を進めながら1周ぶん生成する。`general_from_team_matchups` で固定構築 vs 回転構築の実験データを作る用途を想定。
 
 | パラメータ | 必須 | 説明 |
 |---|---|---|

--- a/src/monocycle_nash/application/matrix_nodes.py
+++ b/src/monocycle_nash/application/matrix_nodes.py
@@ -325,9 +325,9 @@ class CharacterRotatingPairSource(CharacterSource, node_method="character_rotati
             cos_theta = math.cos(theta)
             sin_d_theta = math.sin(self.d + theta)
             cos_d_theta = math.cos(self.d + theta)
-            # Matches the problem definition convention: v=(r*sinθ, r*cosθ).
-            v3 = MatchupVector(self.r3 * sin_theta, self.r3 * cos_theta)
-            v4 = MatchupVector(self.r4 * sin_d_theta, self.r4 * cos_d_theta)
+            # Matches the standard (cos, sin) convention.
+            v3 = MatchupVector(self.r3 * cos_theta, self.r3 * sin_theta)
+            v4 = MatchupVector(self.r4 * cos_d_theta, self.r4 * sin_d_theta)
             characters.append(Character(self.power, v3, f"{self.rotating_label_3_prefix}{suffix}"))
             characters.append(Character(self.power, v4, f"{self.rotating_label_4_prefix}{suffix}"))
             i += 1

--- a/tests/application/test_character_rotating_pair.py
+++ b/tests/application/test_character_rotating_pair.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import math
+import pytest
+from monocycle_nash.application.matrix_nodes import CharacterRotatingPairSource
+from monocycle_nash.domain.character import MatchupVector
+
+def test_rotating_pair_coordinates_should_be_cos_sin() -> None:
+    # theta=0, d=pi/2
+    # v3 = (r3*cos(0), r3*sin(0)) = (1.0, 0.0)
+    # v4 = (r4*cos(pi/2), r4*sin(pi/2)) = (0.0, 2.0)
+    source = CharacterRotatingPairSource(
+        x=10.0,
+        y=20.0,
+        r3=1.0,
+        r4=2.0,
+        d=math.pi / 2,
+        theta_step_rad=math.pi,  # Two steps to keep it simple
+        theta_offset_rad=0.0,
+        power=0.0
+    )
+
+    # CharacterRotatingPairSource.load_characters doesn't actually use the ctx argument
+    characters = source.load_characters(None)  # type: ignore
+
+    # characters[0] -> fixed_label_1 (c1)
+    # characters[1] -> fixed_label_2 (c2)
+    # characters[2] -> g3_000
+    # characters[3] -> g4_000
+
+    v3_0 = characters[2].v
+    v4_0 = characters[3].v
+
+    # These assertions will FAIL with the current implementation
+    assert v3_0.x == pytest.approx(1.0), f"v3_0.x expected 1.0, got {v3_0.x}"
+    assert v3_0.y == pytest.approx(0.0), f"v3_0.y expected 0.0, got {v3_0.y}"
+    assert v4_0.x == pytest.approx(0.0), f"v4_0.x expected 0.0, got {v4_0.x}"
+    assert v4_0.y == pytest.approx(2.0), f"v4_0.y expected 2.0, got {v4_0.y}"
+
+def test_rotating_pair_rotation_direction() -> None:
+    # theta=pi/2, d=0
+    # v3 = (r3*cos(pi/2), r3*sin(pi/2)) = (0.0, 1.0)
+    source = CharacterRotatingPairSource(
+        x=10.0,
+        y=20.0,
+        r3=1.0,
+        r4=1.0,
+        d=0.0,
+        theta_step_rad=math.pi,
+        theta_offset_rad=math.pi / 2,
+        power=0.0
+    )
+
+    characters = source.load_characters(None)  # type: ignore
+    v3_0 = characters[2].v
+
+    # These assertions will FAIL with the current implementation
+    assert v3_0.x == pytest.approx(0.0)
+    assert v3_0.y == pytest.approx(1.0)


### PR DESCRIPTION
`CharacterRotatingPairSource` におけるキャラクターの座標計算が `(r*sin(theta), r*cos(theta))` となっていたため、回転方向が時計回りになっていました。
これを数学的に一般的な `(r*cos(theta), r*sin(theta))` に修正し、反時計回りに回転するように変更しました。

あわせて、修正を検証するためのユニットテスト `tests/application/test_character_rotating_pair.py` を追加しました。

---
*PR created automatically by Jules for task [3315235183394837639](https://jules.google.com/task/3315235183394837639) started by @pyran19*